### PR TITLE
2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 ```hcl
 module whitelist_regions {
   source                = "gettek/policy-as-code/azurerm//modules/definition"
-  version               = "2.0.0"
+  version               = "2.1.0"
   policy_name           = "whitelist_regions"
   display_name          = "Allow resources only in whitelisted regions"
   policy_category       = "General"
@@ -86,7 +86,7 @@ Policy Initiatives are used to combine sets of definitions in order to simplify 
 ```hcl
 module platform_baseline_initiative {
   source                  = "gettek/policy-as-code/azurerm//modules/initiative"
-  version                 = "2.0.0"
+  version                 = "2.1.0"
   initiative_name         = "platform_baseline_initiative"
   initiative_display_name = "[Platform]: Baseline Policy Set"
   initiative_description  = "Collection of policies representing the baseline platform requirements"
@@ -107,7 +107,7 @@ module platform_baseline_initiative {
 ```hcl
 module org_mg_whitelist_regions {
   source                = "gettek/policy-as-code/azurerm//modules/def_assignment"
-  version               = "2.0.0"
+  version               = "2.1.0"
   definition            = module.whitelist_regions.definition
   assignment_scope      = local.default_assignment_scope
   assignment_effect     = "Deny"
@@ -176,7 +176,7 @@ output builtin_policy_metadata {
   value = data.azurerm_policy_definition.builtin_policy.metadata
 }
 ```
-`Output: builtin_policy_metadata = {"category":"Tags","version":"2.0.0"}`
+`Output: builtin_policy_metadata = {"category":"Tags","version":"1.0.0"}`
 
 
 ## Definition and Assignment Scopes
@@ -235,4 +235,4 @@ output builtin_policy_metadata {
 
 ### Error: Invalid for_each argument
 
-You may experience plan/apply issues when running an initial deployment of the `set_assignment` module. To prevent this, set the flag `-var "skip_remediation=true"` and omit for consecutive builds.
+You may experience plan/apply issues when running an initial deployment of the `set_assignment` module. To prevent this, set the flag `-var "skip_remediation=true"` and omit for consecutive builds. This may also be required for destroy tasks.

--- a/modules/cis_benchmark/README.md
+++ b/modules/cis_benchmark/README.md
@@ -26,7 +26,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.84.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
 ## Modules
 

--- a/modules/def_assignment/README.md
+++ b/modules/def_assignment/README.md
@@ -10,7 +10,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.84.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
 ## Modules
 

--- a/modules/def_assignment/main.tf
+++ b/modules/def_assignment/main.tf
@@ -1,4 +1,4 @@
-resource "azurerm_management_group_policy_assignment" "def" {
+resource azurerm_management_group_policy_assignment def {
   count                = local.assignment_scope.mg
   name                 = local.assignment_name
   display_name         = local.display_name
@@ -7,7 +7,6 @@ resource "azurerm_management_group_policy_assignment" "def" {
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
-  metadata             = var.definition.metadata
   parameters           = local.parameters
   location             = var.assignment_location
 
@@ -23,7 +22,7 @@ resource "azurerm_management_group_policy_assignment" "def" {
   }
 }
 
-resource "azurerm_subscription_policy_assignment" "def" {
+resource azurerm_subscription_policy_assignment def {
   count                = local.assignment_scope.sub
   name                 = local.assignment_name
   display_name         = local.display_name
@@ -32,7 +31,6 @@ resource "azurerm_subscription_policy_assignment" "def" {
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
-  metadata             = var.definition.metadata
   parameters           = local.parameters
   location             = var.assignment_location
 
@@ -49,7 +47,7 @@ resource "azurerm_subscription_policy_assignment" "def" {
 }
 
 
-resource "azurerm_resource_group_policy_assignment" "def" {
+resource azurerm_resource_group_policy_assignment def {
   count                = local.assignment_scope.rg
   name                 = local.assignment_name
   display_name         = local.display_name
@@ -58,7 +56,6 @@ resource "azurerm_resource_group_policy_assignment" "def" {
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
-  metadata             = var.definition.metadata
   parameters           = local.parameters
   location             = var.assignment_location
 
@@ -74,7 +71,7 @@ resource "azurerm_resource_group_policy_assignment" "def" {
   }
 }
 
-resource "azurerm_resource_policy_assignment" "def" {
+resource azurerm_resource_policy_assignment def {
   count                = local.assignment_scope.resource
   name                 = local.assignment_name
   display_name         = local.display_name
@@ -83,7 +80,6 @@ resource "azurerm_resource_policy_assignment" "def" {
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
-  metadata             = var.definition.metadata
   parameters           = local.parameters
   location             = var.assignment_location
 
@@ -100,7 +96,7 @@ resource "azurerm_resource_policy_assignment" "def" {
 }
 
 
-resource "azurerm_role_assignment" "rem_role" {
+resource azurerm_role_assignment rem_role {
   for_each                         = toset(local.role_definition_ids)
   scope                            = local.role_assignment_scope
   role_definition_id               = each.value
@@ -109,7 +105,7 @@ resource "azurerm_role_assignment" "rem_role" {
 }
 
 
-resource "azurerm_policy_remediation" "rem" {
+resource azurerm_policy_remediation rem {
   count                   = local.create_remediation ? 1 : 0
   name                    = lower("${var.definition.name}-${formatdate("DD-MM-YYYY-hh:mm:ss", timestamp())}")
   scope                   = var.assignment_scope

--- a/modules/def_assignment/outputs.tf
+++ b/modules/def_assignment/outputs.tf
@@ -13,7 +13,7 @@ output remediation_id {
   value       = azurerm_policy_remediation.rem[*].id
 }
 
-output "role_definition_ids" {
+output role_definition_ids {
   description = "The List of Role Defenition Ids assignable to the managed identity"
-  value = local.role_definition_ids
+  value       = local.role_definition_ids
 }

--- a/modules/definition/README.md
+++ b/modules/definition/README.md
@@ -2,7 +2,7 @@
 
 This module depends on populating `var.policy_category` and `var.policy_name` to correspond with respective policy definition `json` files.
 
-> :bulb: **Note:** More information on Policy Defenition Structure [can be found here](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure)
+> :bulb: **Note:** More information on Policy Definition Structure [can be found here](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure)
 
 
 
@@ -14,7 +14,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.84.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
 ## Modules
 

--- a/modules/definition/TEMPLATE.md
+++ b/modules/definition/TEMPLATE.md
@@ -2,5 +2,5 @@
 
 This module depends on populating `var.policy_category` and `var.policy_name` to correspond with respective policy definition `json` files.
 
-> :bulb: **Note:** More information on Policy Defenition Structure [can be found here](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure)
+> :bulb: **Note:** More information on Policy Definition Structure [can be found here](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure)
 

--- a/modules/initiative/README.md
+++ b/modules/initiative/README.md
@@ -12,7 +12,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.84.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
 ## Modules
 

--- a/modules/initiative/outputs.tf
+++ b/modules/initiative/outputs.tf
@@ -25,5 +25,5 @@ output initiative {
 
 output role_definition_ids {
   description = "Role definition IDs for remediation"
-  value = local.all_role_definition_ids
+  value       = local.all_role_definition_ids
 }

--- a/modules/set_assignment/README.md
+++ b/modules/set_assignment/README.md
@@ -10,7 +10,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.84.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
 ## Modules
 

--- a/modules/set_assignment/main.tf
+++ b/modules/set_assignment/main.tf
@@ -1,4 +1,4 @@
-resource "azurerm_management_group_policy_assignment" "set" {
+resource azurerm_management_group_policy_assignment set {
   count                = local.assignment_scope.mg
   name                 = local.assignment_name
   display_name         = local.display_name
@@ -7,7 +7,6 @@ resource "azurerm_management_group_policy_assignment" "set" {
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
-  metadata             = var.initiative.metadata
   parameters           = local.parameters
   location             = var.assignment_location
 
@@ -23,7 +22,7 @@ resource "azurerm_management_group_policy_assignment" "set" {
   }
 }
 
-resource "azurerm_subscription_policy_assignment" "set" {
+resource azurerm_subscription_policy_assignment set {
   count                = local.assignment_scope.sub
   name                 = local.assignment_name
   display_name         = local.display_name
@@ -32,7 +31,6 @@ resource "azurerm_subscription_policy_assignment" "set" {
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
-  metadata             = var.initiative.metadata
   parameters           = local.parameters
   location             = var.assignment_location
 
@@ -49,7 +47,7 @@ resource "azurerm_subscription_policy_assignment" "set" {
 }
 
 
-resource "azurerm_resource_group_policy_assignment" "set" {
+resource azurerm_resource_group_policy_assignment set {
   count                = local.assignment_scope.rg
   name                 = local.assignment_name
   display_name         = local.display_name
@@ -58,7 +56,6 @@ resource "azurerm_resource_group_policy_assignment" "set" {
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
-  metadata             = var.initiative.metadata
   parameters           = local.parameters
   location             = var.assignment_location
 
@@ -74,7 +71,7 @@ resource "azurerm_resource_group_policy_assignment" "set" {
   }
 }
 
-resource "azurerm_resource_policy_assignment" "set" {
+resource azurerm_resource_policy_assignment set {
   count                = local.assignment_scope.resource
   name                 = local.assignment_name
   display_name         = local.display_name
@@ -83,7 +80,6 @@ resource "azurerm_resource_policy_assignment" "set" {
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
-  metadata             = var.initiative.metadata
   parameters           = local.parameters
   location             = var.assignment_location
 
@@ -99,7 +95,7 @@ resource "azurerm_resource_policy_assignment" "set" {
   }
 }
 
-resource "azurerm_role_assignment" "rem_role" {
+resource azurerm_role_assignment rem_role {
   for_each                         = toset(local.role_definition_ids)
   scope                            = local.role_assignment_scope
   role_definition_id               = each.value
@@ -107,7 +103,7 @@ resource "azurerm_role_assignment" "rem_role" {
   skip_service_principal_aad_check = true
 }
 
-resource "azurerm_policy_remediation" "rem" {
+resource azurerm_policy_remediation rem {
   for_each                       = { for dr in local.definition_reference : basename(dr.policy_definition_id) => dr }
   name                           = lower("${each.key}-${formatdate("DD-MM-YYYY-hh:mm:ss", timestamp())}")
   scope                          = var.assignment_scope


### PR DESCRIPTION
## Remove metadata from assignment modules

An issue exists where policy assignment `metadata` conflicts with provider-generated metadata resulting in an inconsistent final plan on plan/apply stages. These attributes have been removed and a provider bug will be raised.

Azure has since introduced the `system_data` attribute to both policy definitions and assignments which includes these meta fields: `createdBy`, `createdOn`, `updatedBy`, `updatedOn` and is therefore no longer needed.