### PR TITLE
fixed definition references through generation

### DIFF
--- a/.github/workflows/cd-guest-config.yml
+++ b/.github/workflows/cd-guest-config.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Terraform Apply
         id: apply
         if: ${{ success() }}
-        run: terraform apply -var="skip_remediation=true" && terraform apply -var="build_packages=false"
+        run: terraform apply && terraform apply -var="build_packages=false"
         working-directory: examples-guest-config
 
       - name: Terraform Destroy

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Terraform Apply
         id: apply
         if: ${{ success() }}
-        run: terraform apply -var="skip_remediation=true" && terraform apply
+        run: terraform apply
         working-directory: examples
 
       - name: Log in with Azure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: github.event_name == 'pull_request'
-        run: terraform plan -no-color -var="skip_remediation=true"
+        run: terraform plan -no-color
         working-directory: ${{ env.TF_WORKING_DIR }}
         continue-on-error: true
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@
   - [🎯Definition and Assignment Scopes](#definition-and-assignment-scopes)
 - [📘Useful Resources](#useful-resources)
 - [Limitations](#limitations)
-- [Known Issues](#known-issues)
-  - [Error: Invalid for_each argument](#error-invalid-for_each-argument)
-  - [Updating Initiative Member Definitions](#updating-initiative-member-definitions)
 
 ## Repo Folder Structure
 
@@ -83,7 +80,7 @@ This module depends on populating `var.policy_name` and `var.policy_category` to
 ```hcl
 module whitelist_regions {
   source              = "gettek/policy-as-code/azurerm//modules/definition"
-  version             = "2.5.0"
+  version             = "2.5.1"
   policy_name         = "whitelist_regions"
   display_name        = "Allow resources only in whitelisted regions"
   policy_category     = "General"
@@ -102,7 +99,7 @@ Policy Initiatives are used to combine sets of definitions in order to simplify 
 ```hcl
 module platform_baseline_initiative {
   source                  = "gettek/policy-as-code/azurerm//modules/initiative"
-  version                 = "2.5.0"
+  version                 = "2.5.1"
   initiative_name         = "platform_baseline_initiative"
   initiative_display_name = "[Platform]: Baseline Policy Set"
   initiative_description  = "Collection of policies representing the baseline platform requirements"
@@ -123,7 +120,7 @@ module platform_baseline_initiative {
 ```hcl
 module org_mg_whitelist_regions {
   source                = "gettek/policy-as-code/azurerm//modules/def_assignment"
-  version               = "2.5.0"
+  version               = "2.5.1"
   definition            = module.whitelist_regions.definition
   assignment_scope      = data.azurerm_management_group.org.id
   assignment_effect     = "Deny"
@@ -142,12 +139,12 @@ module org_mg_whitelist_regions {
 ```hcl
 module org_mg_platform_diagnostics_initiative {
   source               = "gettek/policy-as-code/azurerm//modules/set_assignment"
-  version              = "2.5.0"
+  version              = "2.5.1"
   initiative           = module.platform_diagnostics_initiative.initiative
   assignment_scope     = data.azurerm_management_group.org.id
   assignment_effect    = "DeployIfNotExists"
   skip_remediation     = var.skip_remediation
-  skip_role_assignment = false
+  skip_role_assignment = var.skip_role_assignment
   role_definition_ids  = module.platform_diagnostics_initiative.role_definition_ids
   assignment_parameters = {
     workspaceId                 = azurerm_log_analytics_workspace.workspace.id
@@ -275,12 +272,3 @@ To trigger an on-demand [compliance scan](https://docs.microsoft.com/en-us/azure
 | Remediation task                                          | Resources                        | 50,000        |
 | Policy definition, initiative, or assignment request body | Bytes                            | 1,048,576     |
 
-## Known Issues
-
-### Error: Invalid for_each argument
-
-You may experience plan/apply issues when running an initial deployment of the `set_assignment` module. This is because `azurerm_role_assignment.rem_role` and `azurerm_*_policy_remediation.rem` depend on resources to exist before producing a successful continuos deployment. To overcome this, set `skip_remediation=true` and omit for consecutive builds. This may also be required for destroy tasks.
-
-### Updating Initiative Member Definitions
-
-Updating Initiatives can become tricky when parameter counts are increased or decreased when `member_definitions` are added or removed, in most cases you will need to recreate the initiative before a successful `set_assignment` e.g:  `terraform apply -var "skip_remediation=true" -target module.example_initiative`

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ No requirements.
 | <a name="module_deny_resources_types"></a> [deny\_resources\_types](#module\_deny\_resources\_types) | ..//modules/definition | n/a |
 | <a name="module_deploy_resource_diagnostic_setting"></a> [deploy\_resource\_diagnostic\_setting](#module\_deploy\_resource\_diagnostic\_setting) | ..//modules/definition | n/a |
 | <a name="module_deploy_subscription_diagnostic_setting"></a> [deploy\_subscription\_diagnostic\_setting](#module\_deploy\_subscription\_diagnostic\_setting) | ..//modules/definition | n/a |
-| <a name="module_exemption_configure_asc_initiative"></a> [exemption\_configure\_asc\_initiative](#module\_exemption\_configure\_asc\_initiative) | ..//modules/exemption | n/a |
+| <a name="module_exemption_subscription_diagnostics_settings"></a> [exemption\_subscription\_diagnostics\_settings](#module\_exemption\_subscription\_diagnostics\_settings) | ..//modules/exemption | n/a |
 | <a name="module_inherit_resource_group_tags_modify"></a> [inherit\_resource\_group\_tags\_modify](#module\_inherit\_resource\_group\_tags\_modify) | ..//modules/definition | n/a |
 | <a name="module_org_mg_configure_asc_initiative"></a> [org\_mg\_configure\_asc\_initiative](#module\_org\_mg\_configure\_asc\_initiative) | ..//modules/set_assignment | n/a |
 | <a name="module_org_mg_configure_az_monitor_linux_vm_initiative"></a> [org\_mg\_configure\_az\_monitor\_linux\_vm\_initiative](#module\_org\_mg\_configure\_az\_monitor\_linux\_vm\_initiative) | ..//modules/set_assignment | n/a |

--- a/examples/backend.tf
+++ b/examples/backend.tf
@@ -9,9 +9,3 @@ terraform {
 provider "azurerm" {
   features {}
 }
-
-provider "azurerm" {
-  alias           = "team_a"
-  subscription_id = data.azurerm_client_config.current.subscription_id
-  features {}
-}

--- a/examples/exemptions.tf
+++ b/examples/exemptions.tf
@@ -1,14 +1,13 @@
-# Resource exemption on multiple key vaults
-module "exemption_configure_asc_initiative" {
+# Subscription Scope Resource Exemption
+module "exemption_subscription_diagnostics_settings" {
   source               = "..//modules/exemption"
-  name                 = "Onboard subscription to ASC Exemption"
+  name                 = "Subscription Diagnostic Settings Exemption"
   display_name         = "Exempted while testing"
-  description          = "Excludes subscription from ASC onboarding during development"
+  description          = "Excludes subscription from configuring diagnostics settings"
   scope                = data.azurerm_subscription.current.id
-  policy_assignment_id = module.org_mg_configure_asc_initiative.id
-  policy_definition_reference_ids = [
-    "69908db02e3d4a578d03",
-    "1428ed118e4dcca5e747"
+  policy_assignment_id = module.org_mg_platform_diagnostics_initiative.id
+  member_definition_names = [
+    "deploy_subscription_diagnostic_setting"
   ]
   exemption_category = "Waiver"
   expires_on         = "2023-05-25"

--- a/modules/definition/README.md
+++ b/modules/definition/README.md
@@ -83,7 +83,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_definition"></a> [definition](#output\_definition) | The complete resource node of the Policy Definition |
+| <a name="output_definition"></a> [definition](#output\_definition) | The combined Policy Definition resource node |
 | <a name="output_id"></a> [id](#output\_id) | The Id of the Policy Definition |
 | <a name="output_metadata"></a> [metadata](#output\_metadata) | The metadata of the Policy Definition |
 | <a name="output_name"></a> [name](#output\_name) | The name of the Policy Definition |

--- a/modules/definition/outputs.tf
+++ b/modules/definition/outputs.tf
@@ -1,6 +1,6 @@
 output id {
   description = "The Id of the Policy Definition"
-  value       = azurerm_policy_definition.def.id
+  value       = local.definition_id
 }
 
 output name {
@@ -24,6 +24,16 @@ output metadata {
 }
 
 output definition {
-  description = "The complete resource node of the Policy Definition"
-  value       = azurerm_policy_definition.def
+  description = "The combined Policy Definition resource node"
+  value = {
+    id                  = local.definition_id
+    name                = var.policy_name
+    display_name        = local.display_name
+    description         = local.description
+    mode                = var.policy_mode
+    management_group_id = var.management_group_id
+    policy_rule         = jsonencode(local.policy_rule)
+    parameters          = jsonencode(local.parameters)
+    metadata            = local.metadata
+  }
 }

--- a/modules/definition/variables.tf
+++ b/modules/definition/variables.tf
@@ -91,4 +91,7 @@ locals {
     { category = try((local.policy_object).properties.metadata.category, var.policy_category) },
     { version = try((local.policy_object).properties.metadata.version, var.policy_version) },
   )) : var.policy_metadata
+
+  # manually generate the definition Id to prevent "Invalid for_each argument" on set_assignment plan/apply
+  definition_id = var.management_group_id != null ? "${var.management_group_id}/providers/Microsoft.Authorization/policyDefinitions/${var.policy_name}" : azurerm_policy_definition.def.id
 }

--- a/modules/exemption/TEMPLATE.md
+++ b/modules/exemption/TEMPLATE.md
@@ -2,6 +2,8 @@
 
 Exemptions can be used where `not_scopes` become time sensitive or require alternative methods of approval for audit trails. Learn more about Azure Policy [exemption structure](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/exemption-structure).
 
+> 💡**Note:** This module also allows you to exempt multiple scope types at once (e.g. resource group and individual resource) when using a `for_each` loop as in the example below.
+
 ## Examples
 
 ### At Management Group Scope with Optional Metadata
@@ -27,6 +29,25 @@ module exemption_team_a_mg_deny_nic_public_ip {
 }
 ```
 
+### Exempt multiple scope types in a for_each loop
+
+```hcl
+module exemption_team_a_mg_deny_nic_public_ip {
+  source = "gettek/policy-as-code/azurerm//modules/exemption"
+  for_each = toset([
+    data.azurerm_management_group.team_a.id,
+    data.azurerm_subscription.current.id,
+    data.azurerm_resource_group.example.id
+    data.azurerm_network_interface.example.id
+  ])
+  name                 = "Deny NIC Public IP Exemption"
+  display_name         = "Exempted while testing"
+  description          = "Allows NIC Public IPs for testing"
+  scope                = each.value
+  policy_assignment_id = module.team_a_mg_deny_nic_public_ip.id
+}
+```
+
 ### Exempt a subset of definitions within an Initiative at Subscription Scope
 
 ```hcl
@@ -35,11 +56,11 @@ module "exemption_configure_asc_initiative" {
   name                            = "Onboard subscription to ASC Exemption"
   display_name                    = "Exempted while testing"
   description                     = "Excludes subscription from ASC onboarding during development"
-  scope                           = "/subscriptions/${var.team_a_subscription_id}"
+  scope                           = data.azurerm_subscription.current.id
   policy_assignment_id            = module.org_mg_configure_asc_initiative.id
-  policy_definition_reference_ids = [
-    "6d237bfef483fbb3308d",
-    "652d1284813c442a7e95"
+  member_definition_names = [
+    "auto_provision_log_analytics_agent_custom_workspace",
+    "auto_set_contact_details"
   ]
 }
 ```
@@ -47,16 +68,12 @@ module "exemption_configure_asc_initiative" {
 ### Resource Group Exemption
 
 ```hcl
-data azurerm_resource_group vms {
-  name = "rg-dev-uks-vms"
-}
-
 module exemption_team_a_mg_deny_nic_public_ip {
   source               = "gettek/policy-as-code/azurerm//modules/exemption"
   name                 = "Deny NIC Public IP Exemption"
   display_name         = "Exempted while testing"
   description          = "Allows NIC Public IPs for testing"
-  scope                = data.azurerm_resource_group.vms.id
+  scope                = data.azurerm_resource_group.example.id
   policy_assignment_id = module.team_a_mg_deny_nic_public_ip.id
 }
 ```

--- a/modules/exemption/main.tf
+++ b/modules/exemption/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_management_group_policy_exemption" "management_group_exemption
   policy_assignment_id            = var.policy_assignment_id
   exemption_category              = var.exemption_category
   expires_on                      = local.expires_on
-  policy_definition_reference_ids = var.policy_definition_reference_ids
+  policy_definition_reference_ids = local.policy_definition_reference_ids
   metadata                        = jsonencode(var.metadata)
 }
 
@@ -20,7 +20,7 @@ resource "azurerm_subscription_policy_exemption" "subscription_exemption" {
   policy_assignment_id            = var.policy_assignment_id
   exemption_category              = var.exemption_category
   expires_on                      = local.expires_on
-  policy_definition_reference_ids = var.policy_definition_reference_ids
+  policy_definition_reference_ids = local.policy_definition_reference_ids
   metadata                        = jsonencode(var.metadata)
 }
 
@@ -33,7 +33,7 @@ resource "azurerm_resource_group_policy_exemption" "resource_group_exemption" {
   policy_assignment_id            = var.policy_assignment_id
   exemption_category              = var.exemption_category
   expires_on                      = local.expires_on
-  policy_definition_reference_ids = var.policy_definition_reference_ids
+  policy_definition_reference_ids = local.policy_definition_reference_ids
   metadata                        = jsonencode(var.metadata)
 }
 
@@ -46,6 +46,6 @@ resource "azurerm_resource_policy_exemption" "resource_exemption" {
   policy_assignment_id            = var.policy_assignment_id
   exemption_category              = var.exemption_category
   expires_on                      = local.expires_on
-  policy_definition_reference_ids = var.policy_definition_reference_ids
+  policy_definition_reference_ids = local.policy_definition_reference_ids
   metadata                        = jsonencode(var.metadata)
 }

--- a/modules/initiative/README.md
+++ b/modules/initiative/README.md
@@ -125,7 +125,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_id"></a> [id](#output\_id) | The Id of the Policy Set Definition |
-| <a name="output_initiative"></a> [initiative](#output\_initiative) | The complete Policy Initiative resource node |
+| <a name="output_initiative"></a> [initiative](#output\_initiative) | The combined Policy Initiative resource node |
 | <a name="output_metadata"></a> [metadata](#output\_metadata) | The metadata of the Policy Set Definition |
 | <a name="output_name"></a> [name](#output\_name) | The name of the Policy Set Definition |
 | <a name="output_parameters"></a> [parameters](#output\_parameters) | The combined parameters of the Policy Set Definition |

--- a/modules/initiative/main.tf
+++ b/modules/initiative/main.tf
@@ -9,17 +9,17 @@ resource azurerm_policy_set_definition set {
   metadata   = local.metadata
   parameters = local.all_parameters
 
-  dynamic "policy_definition_reference" {
+  dynamic policy_definition_reference {
     for_each = [for d in var.member_definitions : {
       id         = d.id
-      ref_id     = substr(md5("${var.initiative_name}${d.id}"), 0, 20)
+      ref_id     = substr(title(replace(d.name, "/-|_|\\s/", " ")), 0, 64)
       parameters = jsondecode(d.parameters)
       groups     = []
     }]
 
     content {
       policy_definition_id = policy_definition_reference.value.id
-      reference_id         = policy_definition_reference.value.ref_id
+      reference_id         = replace(policy_definition_reference.value.ref_id, "/\\s/", "")
       parameter_values = jsonencode({
         for k in keys(policy_definition_reference.value.parameters) :
         k => { value = "[parameters('${k}')]" }

--- a/modules/initiative/outputs.tf
+++ b/modules/initiative/outputs.tf
@@ -1,6 +1,6 @@
 output id {
   description = "The Id of the Policy Set Definition"
-  value       = azurerm_policy_set_definition.set.id
+  value       = local.initiative_id
 }
 
 output name {
@@ -18,12 +18,21 @@ output metadata {
   value       = local.metadata
 }
 
-output initiative {
-  description = "The complete Policy Initiative resource node"
-  value       = azurerm_policy_set_definition.set
-}
-
 output role_definition_ids {
   description = "Role definition IDs for remediation"
   value       = local.all_role_definition_ids
+}
+
+output initiative {
+  description = "The combined Policy Initiative resource node"
+  value = {
+    id                          = local.initiative_id
+    name                        = var.initiative_name
+    display_name                = var.initiative_display_name
+    description                 = var.initiative_description
+    management_group_id         = var.management_group_id
+    parameters                  = local.all_parameters
+    metadata                    = local.metadata
+    policy_definition_reference = azurerm_policy_set_definition.set.policy_definition_reference
+  }
 }

--- a/modules/initiative/variables.tf
+++ b/modules/initiative/variables.tf
@@ -64,14 +64,17 @@ locals {
   # get role definition IDs
   role_definition_ids = {
     for d in var.member_definitions :
-    d.id => try(jsondecode(d.policy_rule).then.details.roleDefinitionIds, [])
+    d.name => try(jsondecode(d.policy_rule).then.details.roleDefinitionIds, [])
   }
 
   # combine all discovered role definition IDs
-  all_role_definition_ids = distinct([for v in flatten(values(local.role_definition_ids)) : lower(v)])
+  all_role_definition_ids = try(distinct([for v in flatten(values(local.role_definition_ids)) : lower(v)]), [])
 
   metadata = jsonencode(merge(
     { category = var.initiative_category },
     { version = var.initiative_version },
   ))
+
+  # manually generate the initiative Id to prevent "Invalid for_each argument" on potential consumer modules
+  initiative_id = var.management_group_id != null ? "${var.management_group_id}/providers/Microsoft.Authorization/policySetDefinitions/${var.initiative_name}" : azurerm_policy_set_definition.set.id
 }

--- a/modules/set_assignment/README.md
+++ b/modules/set_assignment/README.md
@@ -4,8 +4,6 @@ Assignments can be scoped from overarching management groups right down to indiv
 
 > 💡 To automate Role Assignment and Remediation you must explicitly parse a list of required `role_definition_ids` to this module as seen below. You may choose to assign roles at a different scope to that of the policy assignment (default) using `role_assignment_scope`.
 
-> ⚠️ **Warning:** You may experience plan/apply issues when running an initial deployment of a `set_assignment`. This is because `azurerm_role_assignment.rem_role` and `azurerm_*_policy_remediation.rem` depend on resources to exist before producing a successful deployment. To overcome this, set the flag `skip_remediation=true` and omit for consecutive builds. This may also be required for destroy tasks.
-
 ## Examples
 
 ### Custom Policy Initiative Assignment with Not-Scope
@@ -15,7 +13,7 @@ module org_mg_configure_asc_initiative {
   initiative           = module.configure_asc_initiative.initiative
   assignment_scope     = data.azurerm_management_group.org.id
   assignment_effect    = "DeployIfNotExists"
-  skip_remediation     = var.skip_remediation
+  skip_remediation     = false
   skip_role_assignment = false
   role_definition_ids  = module.configure_asc_initiative.role_definition_ids
 
@@ -66,7 +64,7 @@ module org_mg_configure_az_monitor_linux_vm_initiative {
   source           = "gettek/policy-as-code/azurerm//modules/set_assignment"
   initiative       = data.azurerm_policy_set_definition.configure_az_monitor_linux_vm_initiative
   assignment_scope = data.azurerm_management_group.org.id
-  skip_remediation = var.skip_remediation
+  skip_remediation = false
 
   role_definition_ids = [
     data.azurerm_role_definition.vm_contributor.id
@@ -74,7 +72,7 @@ module org_mg_configure_az_monitor_linux_vm_initiative {
 
   assignment_parameters = {
     listOfLinuxImageIdToInclude = []
-    dcrResourceId                 = "/Data/Collection/Rule/Resource/Id"
+    dcrResourceId               = "/Data/Collection/Rule/Resource/Id"
   }
 }
 ```
@@ -129,7 +127,7 @@ No modules.
 | <a name="input_non_compliance_message"></a> [non\_compliance\_message](#input\_non\_compliance\_message) | The optional non-compliance message text. This message will be the default for all member definitions in the set. | `string` | `""` | no |
 | <a name="input_resource_discovery_mode"></a> [resource\_discovery\_mode](#input\_resource\_discovery\_mode) | The way that resources to remediate are discovered. Possible values are ExistingNonCompliant or ReEvaluateCompliance. Defaults to ExistingNonCompliant | `string` | `"ExistingNonCompliant"` | no |
 | <a name="input_role_assignment_scope"></a> [role\_assignment\_scope](#input\_role\_assignment\_scope) | The scope at which role definition(s) will be assigned, defaults to Policy Assignment Scope. Must be full resource IDs. Changing this forces a new resource to be created | `string` | `null` | no |
-| <a name="input_role_definition_ids"></a> [role\_definition\_ids](#input\_role\_definition\_ids) | List of Role definition ID's for the System Assigned Identity. Omit this to skip creating role assignments. Changing this forces a new resource to be created | `list(any)` | `[]` | no |
+| <a name="input_role_definition_ids"></a> [role\_definition\_ids](#input\_role\_definition\_ids) | List of Role definition ID's for the System Assigned Identity. Omit this to use those located in policy definitions. Changing this forces a new resource to be created | `list(string)` | `[]` | no |
 | <a name="input_skip_remediation"></a> [skip\_remediation](#input\_skip\_remediation) | Should the module skip creation of a remediation task for policies that DeployIfNotExists and Modify | `bool` | `false` | no |
 | <a name="input_skip_role_assignment"></a> [skip\_role\_assignment](#input\_skip\_role\_assignment) | Should the module skip creation of role assignment for policies that DeployIfNotExists and Modify | `bool` | `false` | no |
 
@@ -137,6 +135,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_definition_references"></a> [definition\_references](#output\_definition\_references) | The Member Definition Reference Ids |
 | <a name="output_id"></a> [id](#output\_id) | The Policy Assignment Id |
-| <a name="output_identity_id"></a> [identity\_id](#output\_identity\_id) | The Managed Identity block containing Principal Id & Tenant Id of this Policy Assignment if type is SystemAssigned |
+| <a name="output_principal_id"></a> [principal\_id](#output\_principal\_id) | The Principal Id of this Policy Assignment's Managed Identity if type is SystemAssigned |
 | <a name="output_remediation_tasks"></a> [remediation\_tasks](#output\_remediation\_tasks) | The Remediation Task Ids and related Policy Definition Ids |

--- a/modules/set_assignment/TEMPLATE.md
+++ b/modules/set_assignment/TEMPLATE.md
@@ -4,8 +4,6 @@ Assignments can be scoped from overarching management groups right down to indiv
 
 > 💡 To automate Role Assignment and Remediation you must explicitly parse a list of required `role_definition_ids` to this module as seen below. You may choose to assign roles at a different scope to that of the policy assignment (default) using `role_assignment_scope`.
 
-> ⚠️ **Warning:** You may experience plan/apply issues when running an initial deployment of a `set_assignment`. This is because `azurerm_role_assignment.rem_role` and `azurerm_*_policy_remediation.rem` depend on resources to exist before producing a successful deployment. To overcome this, set the flag `skip_remediation=true` and omit for consecutive builds. This may also be required for destroy tasks.
-
 ## Examples
 
 ### Custom Policy Initiative Assignment with Not-Scope
@@ -15,7 +13,7 @@ module org_mg_configure_asc_initiative {
   initiative           = module.configure_asc_initiative.initiative
   assignment_scope     = data.azurerm_management_group.org.id
   assignment_effect    = "DeployIfNotExists"
-  skip_remediation     = var.skip_remediation
+  skip_remediation     = false
   skip_role_assignment = false
   role_definition_ids  = module.configure_asc_initiative.role_definition_ids
 
@@ -66,7 +64,7 @@ module org_mg_configure_az_monitor_linux_vm_initiative {
   source           = "gettek/policy-as-code/azurerm//modules/set_assignment"
   initiative       = data.azurerm_policy_set_definition.configure_az_monitor_linux_vm_initiative
   assignment_scope = data.azurerm_management_group.org.id
-  skip_remediation = var.skip_remediation
+  skip_remediation = false
 
   role_definition_ids = [
     data.azurerm_role_definition.vm_contributor.id
@@ -74,7 +72,7 @@ module org_mg_configure_az_monitor_linux_vm_initiative {
 
   assignment_parameters = {
     listOfLinuxImageIdToInclude = []
-    dcrResourceId                 = "/Data/Collection/Rule/Resource/Id"
+    dcrResourceId               = "/Data/Collection/Rule/Resource/Id"
   }
 }
 ```

--- a/modules/set_assignment/main.tf
+++ b/modules/set_assignment/main.tf
@@ -113,13 +113,13 @@ resource azurerm_role_assignment rem_role {
   for_each                         = toset(local.role_definition_ids)
   scope                            = local.role_assignment_scope
   role_definition_id               = each.value
-  principal_id                     = local.principal_id
+  principal_id                     = local.assignment.identity[0].principal_id
   skip_service_principal_aad_check = true
 }
 
 ## remediation tasks ##
 resource azurerm_management_group_policy_remediation rem {
-  for_each                = { for dr in local.definition_reference.mg : basename(dr.policy_definition_id) => dr }
+  for_each                = { for dr in local.definition_reference.mg : basename(dr.reference_id) => dr }
   name                    = lower("${each.key}-${formatdate("DD-MM-YYYY-hh:mm:ss", timestamp())}")
   management_group_id     = var.assignment_scope
   policy_assignment_id    = lower(azurerm_management_group_policy_assignment.set[0].id)
@@ -134,7 +134,7 @@ resource azurerm_management_group_policy_remediation rem {
 }
 
 resource azurerm_subscription_policy_remediation rem {
-  for_each                = { for dr in local.definition_reference.sub : basename(dr.policy_definition_id) => dr }
+  for_each                = { for dr in local.definition_reference.sub : basename(dr.reference_id) => dr }
   name                    = lower("${each.key}-${formatdate("DD-MM-YYYY-hh:mm:ss", timestamp())}")
   subscription_id         = var.assignment_scope
   policy_assignment_id    = lower(azurerm_subscription_policy_assignment.set[0].id)
@@ -149,7 +149,7 @@ resource azurerm_subscription_policy_remediation rem {
 }
 
 resource azurerm_resource_group_policy_remediation rem {
-  for_each                = { for dr in local.definition_reference.rg : basename(dr.policy_definition_id) => dr }
+  for_each                = { for dr in local.definition_reference.rg : basename(dr.reference_id) => dr }
   name                    = lower("${each.key}-${formatdate("DD-MM-YYYY-hh:mm:ss", timestamp())}")
   resource_group_id       = var.assignment_scope
   policy_assignment_id    = lower(azurerm_resource_group_policy_assignment.set[0].id)
@@ -164,7 +164,7 @@ resource azurerm_resource_group_policy_remediation rem {
 }
 
 resource azurerm_resource_policy_remediation rem {
-  for_each                = { for dr in local.definition_reference.resource : basename(dr.policy_definition_id) => dr }
+  for_each                = { for dr in local.definition_reference.resource : basename(dr.reference_id) => dr }
   name                    = lower("${each.key}-${formatdate("DD-MM-YYYY-hh:mm:ss", timestamp())}")
   resource_id             = var.assignment_scope
   policy_assignment_id    = lower(azurerm_resource_policy_assignment.set[0].id)

--- a/modules/set_assignment/outputs.tf
+++ b/modules/set_assignment/outputs.tf
@@ -1,11 +1,11 @@
 output id {
   description = "The Policy Assignment Id"
-  value       = local.assignment_id
+  value       = local.assignment.id
 }
 
-output identity_id {
-  description = "The Managed Identity block containing Principal Id & Tenant Id of this Policy Assignment if type is SystemAssigned"
-  value       = local.principal_id
+output principal_id {
+  description = "The Principal Id of this Policy Assignment's Managed Identity if type is SystemAssigned"
+  value       = local.assignment.identity[0].principal_id
 }
 
 output remediation_tasks {
@@ -17,4 +17,9 @@ output remediation_tasks {
       "policy_definition_id" = rem.policy_definition_id
     })
   ]
+}
+
+output definition_references {
+  description = "The Member Definition Reference Ids"
+  value       = try(var.initiative.policy_definition_reference, [])
 }


### PR DESCRIPTION
# Pull Request Template

Fixes #17 

## Description

- Fixes old issue where initial plan/apply of `set_assignment` would suffer from an `Error: Invalid for_each argument`. Now there is no need to run `-var="skip_remediation=true"` on first time plan/apply.
- `policy_definition_reference_ids` are no longer md5 hashed making it easier to identify references.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

**Test Configuration**:
* Module Version: 2.5.1
* Terraform Version: 1.1.9
* AzureRM Provider Version: 3.4.0
