### PR TITLE
2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This module depends on populating `var.policy_name` and `var.policy_category` to
 ```hcl
 module whitelist_regions {
   source              = "gettek/policy-as-code/azurerm//modules/definition"
-  version             = "2.6.0"
+  version             = "2.6.1"
   policy_name         = "whitelist_regions"
   display_name        = "Allow resources only in whitelisted regions"
   policy_category     = "General"
@@ -97,7 +97,7 @@ Policy Initiatives are used to combine sets of definitions in order to simplify 
 ```hcl
 module platform_baseline_initiative {
   source                  = "gettek/policy-as-code/azurerm//modules/initiative"
-  version                 = "2.6.0"
+  version                 = "2.6.1"
   initiative_name         = "platform_baseline_initiative"
   initiative_display_name = "[Platform]: Baseline Policy Set"
   initiative_description  = "Collection of policies representing the baseline platform requirements"
@@ -120,7 +120,7 @@ module platform_baseline_initiative {
 ```hcl
 module org_mg_whitelist_regions {
   source            = "gettek/policy-as-code/azurerm//modules/def_assignment"
-  version           = "2.6.0"
+  version           = "2.6.1"
   definition        = module.whitelist_regions.definition
   assignment_scope  = data.azurerm_management_group.org.id
   assignment_effect = "Deny"
@@ -142,7 +142,7 @@ module org_mg_whitelist_regions {
 ```hcl
 module org_mg_platform_diagnostics_initiative {
   source                  = "gettek/policy-as-code/azurerm//modules/set_assignment"
-  version                 = "2.6.0"
+  version                 = "2.6.1"
   initiative              = module.platform_diagnostics_initiative.initiative
   assignment_scope        = data.azurerm_management_group.org.id
   assignment_effect       = "DeployIfNotExists"
@@ -164,7 +164,10 @@ module org_mg_platform_diagnostics_initiative {
     data.azurerm_management_group.team_a.id
   ]
 
-  non_compliance_message = "Display this non-compliance message as opposed to a less informal policy error"
+  non_compliance_messages = {
+    null                                        = "The Default non-compliance message for all member definitions"
+    "DeployApplicationGatewayDiagnosticSetting" = "The non-compliance message for the deploy_application_gateway_diagnostic_setting definition"
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ To trigger an on-demand [compliance scan](https://docs.microsoft.com/en-us/azure
 - [Microsoft Tutorial: Security Center - Working with security policies](https://docs.microsoft.com/en-us/azure/security-center/tutorial-security-policy)
 - [VSCode Marketplace: Azure Policy Extension](https://marketplace.visualstudio.com/items?itemName=AzurePolicy.azurepolicyextension)
 - [AzAdvertizer: Release and change tracking on Azure Governance capabilities](https://www.azadvertizer.net/index.html)
+- [Azure Citadel: Creating Custom Policies](https://www.azurecitadel.com/policy/custom/)
 - [Terraform Provider: azurerm_policy_definition](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_definition)
 - [Terraform Provider: azurerm_policy_set_definition](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_set_definition)
 - [Terraform Provider: multiple assignment resources: azurerm_*_policy_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_policy_assignment)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ module platform_baseline_initiative {
 }
 ```
 
-> ⚠️ **Warning:** If any two `member_definitions` contain the same parameter keys then they will be [merged](https://www.terraform.io/language/functions/merge) by this module [as seen here](modules/initiative/variables.tf#L63-L66), in most cases this is beneficial but if mixed values are required during assignment it may be best practice to change the parameter name within each definition, for example `"whitelist_resources_effect"` instead of `"effect"`.
+> ⚠️ **Warning:** If any two `member_definition_ids` contain the same parameters then they will be [merged](https://www.terraform.io/language/functions/merge) by this module (except for `"effect"` when setting `merge_effects = false`) [as seen here](modules/initiative/variables.tf#L74-L81). In most cases this is beneficial but if unique values are required it may be best practice to set unique keys directly within your custom definition.json files such as `[parameters('listOfResourceTypesAllowed_WhitelistResources')]` instead of `[parameters('listOfResourceTypesAllowed')]`.
 
 > 📘 [Microsoft Docs: Azure Policy initiative definition structure](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/initiative-definition-structure)
 

--- a/examples/assignments_org.tf
+++ b/examples/assignments_org.tf
@@ -56,18 +56,32 @@ module "org_mg_platform_diagnostics_initiative" {
   source               = "..//modules/set_assignment"
   initiative           = module.platform_diagnostics_initiative.initiative
   assignment_scope     = data.azurerm_management_group.org.id
-  assignment_effect    = "AuditIfNotExists"
-  # we do not need to create role assignments or remediations in audit effect hence:
   skip_remediation     = true
-  skip_role_assignment = true
+  skip_role_assignment = false
+
+  role_definition_ids = [
+    data.azurerm_role_definition.contributor.id # using explicit roles
+  ]
 
   assignment_parameters = {
-    workspaceId                 = local.dummy_resource_ids.azurerm_log_analytics_workspace
-    storageAccountId            = local.dummy_resource_ids.azurerm_storage_account
-    eventHubName                = local.dummy_resource_ids.azurerm_eventhub_namespace
-    eventHubAuthorizationRuleId = local.dummy_resource_ids.azurerm_eventhub_namespace_authorization_rule
-    metricsEnabled              = "True"
-    logsEnabled                 = "True"
+    workspaceId                                        = local.dummy_resource_ids.azurerm_log_analytics_workspace
+    storageAccountId                                   = local.dummy_resource_ids.azurerm_storage_account
+    eventHubName                                       = local.dummy_resource_ids.azurerm_eventhub_namespace
+    eventHubAuthorizationRuleId                        = local.dummy_resource_ids.azurerm_eventhub_namespace_authorization_rule
+    metricsEnabled                                     = "True"
+    logsEnabled                                        = "True"
+    effect_DeployApplicationGatewayDiagnosticSetting   = "DeployIfNotExists"
+    effect_DeployEventhubDiagnosticSetting             = "DeployIfNotExists"
+    effect_DeployFirewallDiagnosticSetting             = "DeployIfNotExists"
+    effect_DeployKeyvaultDiagnosticSetting             = "AuditIfNotExists"
+    effect_DeployLoadbalancerDiagnosticSetting         = "AuditIfNotExists"
+    effect_DeployNetworkInterfaceDiagnosticSetting     = "AuditIfNotExists"
+    effect_DeployNetworkSecurityGroupDiagnosticSetting = "AuditIfNotExists"
+    effect_DeployPublicIpDiagnosticSetting             = "AuditIfNotExists"
+    effect_DeployStorageAccountDiagnosticSetting       = "DeployIfNotExists"
+    effect_DeploySubscriptionDiagnosticSetting         = "DeployIfNotExists"
+    effect_DeployVnetDiagnosticSetting                 = "AuditIfNotExists"
+    effect_DeployVnetGatewayDiagnosticSetting          = "AuditIfNotExists"
   }
 }
 

--- a/examples/assignments_org.tf
+++ b/examples/assignments_org.tf
@@ -63,6 +63,11 @@ module "org_mg_platform_diagnostics_initiative" {
     data.azurerm_role_definition.contributor.id # using explicit roles
   ]
 
+  non_compliance_messages = {
+    null                                        = "The Default non-compliance message for all member definitions"
+    "DeployApplicationGatewayDiagnosticSetting" = "The non-compliance message for the deploy_application_gateway_diagnostic_setting definition"
+  }
+
   assignment_parameters = {
     workspaceId                                        = local.dummy_resource_ids.azurerm_log_analytics_workspace
     storageAccountId                                   = local.dummy_resource_ids.azurerm_storage_account

--- a/examples/assignments_org.tf
+++ b/examples/assignments_org.tf
@@ -14,6 +14,13 @@ module "org_mg_whitelist_regions" {
       "Global"
     ]
   }
+
+  assignment_metadata = {
+    version   = "1.0.0"
+    category  = "Batch"
+    propertyA = "A"
+    propertyB = "B"
+  }
 }
 
 

--- a/examples/built-in.tf
+++ b/examples/built-in.tf
@@ -12,8 +12,8 @@ module "org_mg_configure_az_monitor_linux_vm_initiative" {
   source               = "..//modules/set_assignment"
   initiative           = data.azurerm_policy_set_definition.configure_az_monitor_linux_vm_initiative
   assignment_scope     = data.azurerm_management_group.org.id
-  skip_remediation     = true
-  skip_role_assignment = true
+  skip_remediation     = var.skip_remediation
+  skip_role_assignment = var.skip_role_assignment
 
   # built-ins that deploy/modify require role-definitions to be present
   role_definition_ids = [

--- a/examples/built-in.tf
+++ b/examples/built-in.tf
@@ -12,8 +12,8 @@ module "org_mg_configure_az_monitor_linux_vm_initiative" {
   source               = "..//modules/set_assignment"
   initiative           = data.azurerm_policy_set_definition.configure_az_monitor_linux_vm_initiative
   assignment_scope     = data.azurerm_management_group.org.id
-  skip_remediation     = var.skip_remediation
-  skip_role_assignment = var.skip_role_assignment
+  skip_remediation     = true
+  skip_role_assignment = true
 
   # built-ins that deploy/modify require role-definitions to be present
   role_definition_ids = [

--- a/examples/initiatives.tf
+++ b/examples/initiatives.tf
@@ -24,6 +24,7 @@ module "platform_diagnostics_initiative" {
   initiative_display_name = "[Platform]: Diagnostics Settings Policy Initiative"
   initiative_description  = "Collection of policies that deploy resource and activity log forwarders to logging core resources"
   initiative_category     = "Monitoring"
+  merge_effects           = false
   management_group_id     = data.azurerm_management_group.org.id
 
   member_definitions = [

--- a/examples/initiatives.tf
+++ b/examples/initiatives.tf
@@ -24,7 +24,7 @@ module "platform_diagnostics_initiative" {
   initiative_display_name = "[Platform]: Diagnostics Settings Policy Initiative"
   initiative_description  = "Collection of policies that deploy resource and activity log forwarders to logging core resources"
   initiative_category     = "Monitoring"
-  merge_effects           = false
+  merge_effects           = false # will not merge "effect" parameters
   management_group_id     = data.azurerm_management_group.org.id
 
   member_definitions = [

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -5,11 +5,11 @@
 variable "skip_remediation" {
   type        = bool
   description = "Skip creation of all remediation tasks for policies that DeployIfNotExists and Modify"
-  default     = false
+  default     = true
 }
 
 variable "skip_role_assignment" {
   type        = bool
   description = "Should the module skip creation of role assignment for policies that DeployIfNotExists and Modify"
-  default     = false
+  default     = true
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -5,11 +5,11 @@
 variable "skip_remediation" {
   type        = bool
   description = "Skip creation of all remediation tasks for policies that DeployIfNotExists and Modify"
-  default     = true
+  default     = false
 }
 
 variable "skip_role_assignment" {
   type        = bool
   description = "Should the module skip creation of role assignment for policies that DeployIfNotExists and Modify"
-  default     = true
+  default     = false
 }

--- a/modules/def_assignment/README.md
+++ b/modules/def_assignment/README.md
@@ -142,6 +142,7 @@ No modules.
 | <a name="input_assignment_effect"></a> [assignment\_effect](#input\_assignment\_effect) | The effect of the policy. Changing this forces a new resource to be created | `string` | `null` | no |
 | <a name="input_assignment_enforcement_mode"></a> [assignment\_enforcement\_mode](#input\_assignment\_enforcement\_mode) | Control whether the assignment is enforced | `bool` | `true` | no |
 | <a name="input_assignment_location"></a> [assignment\_location](#input\_assignment\_location) | The Azure location where this policy assignment should exist, required when an Identity is assigned. Defaults to UK South. Changing this forces a new resource to be created | `string` | `"uksouth"` | no |
+| <a name="input_assignment_metadata"></a> [assignment\_metadata](#input\_assignment\_metadata) | The optional metadata for the policy assignment. | `any` | `{}` | no |
 | <a name="input_assignment_name"></a> [assignment\_name](#input\_assignment\_name) | The name which should be used for this Policy Assignment, defaults to definition name. Changing this forces a new Policy Assignment to be created | `string` | `""` | no |
 | <a name="input_assignment_not_scopes"></a> [assignment\_not\_scopes](#input\_assignment\_not\_scopes) | A list of the Policy Assignment's excluded scopes. Must be full resource IDs | `list(any)` | `[]` | no |
 | <a name="input_assignment_parameters"></a> [assignment\_parameters](#input\_assignment\_parameters) | The policy assignment parameters. Changing this forces a new resource to be created | `any` | `null` | no |

--- a/modules/def_assignment/README.md
+++ b/modules/def_assignment/README.md
@@ -142,7 +142,7 @@ No modules.
 | <a name="input_assignment_effect"></a> [assignment\_effect](#input\_assignment\_effect) | The effect of the policy. Changing this forces a new resource to be created | `string` | `null` | no |
 | <a name="input_assignment_enforcement_mode"></a> [assignment\_enforcement\_mode](#input\_assignment\_enforcement\_mode) | Control whether the assignment is enforced | `bool` | `true` | no |
 | <a name="input_assignment_location"></a> [assignment\_location](#input\_assignment\_location) | The Azure location where this policy assignment should exist, required when an Identity is assigned. Defaults to UK South. Changing this forces a new resource to be created | `string` | `"uksouth"` | no |
-| <a name="input_assignment_metadata"></a> [assignment\_metadata](#input\_assignment\_metadata) | The optional metadata for the policy assignment. | `any` | `{}` | no |
+| <a name="input_assignment_metadata"></a> [assignment\_metadata](#input\_assignment\_metadata) | The optional metadata for the policy assignment. | `any` | `null` | no |
 | <a name="input_assignment_name"></a> [assignment\_name](#input\_assignment\_name) | The name which should be used for this Policy Assignment, defaults to definition name. Changing this forces a new Policy Assignment to be created | `string` | `""` | no |
 | <a name="input_assignment_not_scopes"></a> [assignment\_not\_scopes](#input\_assignment\_not\_scopes) | A list of the Policy Assignment's excluded scopes. Must be full resource IDs | `list(any)` | `[]` | no |
 | <a name="input_assignment_parameters"></a> [assignment\_parameters](#input\_assignment\_parameters) | The policy assignment parameters. Changing this forces a new resource to be created | `any` | `null` | no |

--- a/modules/def_assignment/main.tf
+++ b/modules/def_assignment/main.tf
@@ -3,12 +3,12 @@ resource azurerm_management_group_policy_assignment def {
   name                 = local.assignment_name
   display_name         = local.display_name
   description          = local.description
+  metadata             = local.metadata
+  parameters           = local.parameters
   management_group_id  = var.assignment_scope
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
-  parameters           = local.parameters
-  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -32,12 +32,12 @@ resource azurerm_subscription_policy_assignment def {
   name                 = local.assignment_name
   display_name         = local.display_name
   description          = local.description
+  metadata             = local.metadata
+  parameters           = local.parameters
   subscription_id      = var.assignment_scope
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
-  parameters           = local.parameters
-  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -62,12 +62,12 @@ resource azurerm_resource_group_policy_assignment def {
   name                 = local.assignment_name
   display_name         = local.display_name
   description          = local.description
+  metadata             = local.metadata
+  parameters           = local.parameters
   resource_group_id    = var.assignment_scope
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
-  parameters           = local.parameters
-  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -91,12 +91,12 @@ resource azurerm_resource_policy_assignment def {
   name                 = local.assignment_name
   display_name         = local.display_name
   description          = local.description
+  metadata             = local.metadata
+  parameters           = local.parameters
   resource_id          = var.assignment_scope
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
-  parameters           = local.parameters
-  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {

--- a/modules/def_assignment/main.tf
+++ b/modules/def_assignment/main.tf
@@ -8,6 +8,7 @@ resource azurerm_management_group_policy_assignment def {
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
   parameters           = local.parameters
+  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -35,6 +36,7 @@ resource azurerm_subscription_policy_assignment def {
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
   parameters           = local.parameters
+  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -63,6 +65,7 @@ resource azurerm_resource_group_policy_assignment def {
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
   parameters           = local.parameters
+  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -90,6 +93,7 @@ resource azurerm_resource_policy_assignment def {
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.definition.id
   parameters           = local.parameters
+  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {

--- a/modules/def_assignment/main.tf
+++ b/modules/def_assignment/main.tf
@@ -21,7 +21,8 @@ resource azurerm_management_group_policy_assignment def {
   dynamic "identity" {
     for_each = local.identity_type
     content {
-      type = identity.value
+      type         = identity.value
+      identity_ids = []
     }
   }
 }
@@ -49,7 +50,8 @@ resource azurerm_subscription_policy_assignment def {
   dynamic "identity" {
     for_each = local.identity_type
     content {
-      type = identity.value
+      type         = identity.value
+      identity_ids = []
     }
   }
 }
@@ -78,7 +80,8 @@ resource azurerm_resource_group_policy_assignment def {
   dynamic "identity" {
     for_each = local.identity_type
     content {
-      type = identity.value
+      type         = identity.value
+      identity_ids = []
     }
   }
 }
@@ -106,7 +109,8 @@ resource azurerm_resource_policy_assignment def {
   dynamic "identity" {
     for_each = local.identity_type
     content {
-      type = identity.value
+      type         = identity.value
+      identity_ids = []
     }
   }
 }

--- a/modules/def_assignment/variables.tf
+++ b/modules/def_assignment/variables.tf
@@ -120,7 +120,7 @@ locals {
   assignment_name = try(lower(substr(coalesce(var.assignment_name, var.definition.name), 0, 24)), "")
   display_name = try(coalesce(var.assignment_display_name, var.definition.display_name), "")
   description = try(coalesce(var.assignment_description, var.definition.description), "")
-  metadata = jsonencode(try(coalesce(var.assignment_metadata, var.definition.metadata), {}))
+  metadata = jsonencode(try(coalesce(var.assignment_metadata, jsondecode(var.definition.metadata)), {}))
 
   # convert assignment parameters to the required assignment structure
   parameter_values = var.assignment_parameters != null ? {

--- a/modules/def_assignment/variables.tf
+++ b/modules/def_assignment/variables.tf
@@ -44,6 +44,12 @@ variable assignment_parameters {
   default     = null
 }
 
+variable assignment_metadata {
+  type        = any
+  description = "The optional metadata for the policy assignment."
+  default     = {}
+}
+
 variable assignment_enforcement_mode {
   type        = bool
   description = "Control whether the assignment is enforced"

--- a/modules/def_assignment/variables.tf
+++ b/modules/def_assignment/variables.tf
@@ -47,7 +47,7 @@ variable assignment_parameters {
 variable assignment_metadata {
   type        = any
   description = "The optional metadata for the policy assignment."
-  default     = {}
+  default     = null
 }
 
 variable assignment_enforcement_mode {
@@ -118,20 +118,9 @@ variable skip_role_assignment {
 locals {
   # assignment_name will be trimmed if exceeds 24 characters
   assignment_name = try(lower(substr(coalesce(var.assignment_name, var.definition.name), 0, 24)), "")
-
-  # evaluate policy assignment scope from resource identifier
-  assignment_scope = try({
-    mg       = length(regexall("(\\/managementGroups\\/)", var.assignment_scope)) > 0 ? 1 : 0,
-    sub      = length(split("/", var.assignment_scope)) == 3 ? 1 : 0,
-    rg       = length(regexall("(\\/managementGroups\\/)", var.assignment_scope)) < 1 ? length(split("/", var.assignment_scope)) == 5 ? 1 : 0 : 0,
-    resource = length(split("/", var.assignment_scope)) >= 6 ? 1 : 0,
-  })
-
-  # definition display_name will be used if omitted
   display_name = try(coalesce(var.assignment_display_name, var.definition.display_name), "")
-
-  # definition discription will be used if omitted
   description = try(coalesce(var.assignment_description, var.definition.description), "")
+  metadata = jsonencode(try(coalesce(var.assignment_metadata, var.definition.metadata), {}))
 
   # convert assignment parameters to the required assignment structure
   parameter_values = var.assignment_parameters != null ? {
@@ -148,7 +137,7 @@ locals {
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), [])) > 0 ? { type = "SystemAssigned" } : {}
 
-  # try to use policy definition roles if ommitted
+  # try to use policy definition roles if explicit roles are ommitted
   role_definition_ids = var.skip_role_assignment == false ? try(coalescelist(var.role_definition_ids, lookup(jsondecode(var.definition.policy_rule).then.details, "roleDefinitionIds", [])), []) : []
 
   # policy assignment scope will be used if omitted
@@ -156,6 +145,14 @@ locals {
 
   # if creating role assignments also create a remediation task for policies with DeployIfNotExists and Modify effects
   create_remediation = var.skip_remediation == false && length(local.identity_type) > 0 ? 1 : 0
+
+  # evaluate policy assignment scope from resource identifier
+  assignment_scope = try({
+    mg       = length(regexall("(\\/managementGroups\\/)", var.assignment_scope)) > 0 ? 1 : 0,
+    sub      = length(split("/", var.assignment_scope)) == 3 ? 1 : 0,
+    rg       = length(regexall("(\\/managementGroups\\/)", var.assignment_scope)) < 1 ? length(split("/", var.assignment_scope)) == 5 ? 1 : 0 : 0,
+    resource = length(split("/", var.assignment_scope)) >= 6 ? 1 : 0,
+  })
 
   # evaluate remediation scope from resource identifier
   remediation_scope = try(coalesce(var.remediation_scope, var.assignment_scope), "")

--- a/modules/definition/main.tf
+++ b/modules/definition/main.tf
@@ -7,9 +7,9 @@ resource azurerm_policy_definition def {
 
   management_group_id = var.management_group_id
 
-  policy_rule = jsonencode(local.policy_rule)
-  parameters  = jsonencode(local.parameters)
   metadata    = jsonencode(local.metadata)
+  parameters  = jsonencode(local.parameters)
+  policy_rule = jsonencode(local.policy_rule)
 
   lifecycle {
     create_before_destroy = true

--- a/modules/definition/outputs.tf
+++ b/modules/definition/outputs.tf
@@ -32,8 +32,8 @@ output definition {
     description         = local.description
     mode                = var.policy_mode
     management_group_id = var.management_group_id
-    policy_rule         = jsonencode(local.policy_rule)
-    parameters          = jsonencode(local.parameters)
     metadata            = local.metadata
+    parameters          = jsonencode(local.parameters)
+    policy_rule         = jsonencode(local.policy_rule)
   }
 }

--- a/modules/definition/outputs.tf
+++ b/modules/definition/outputs.tf
@@ -32,7 +32,7 @@ output definition {
     description         = local.description
     mode                = var.policy_mode
     management_group_id = var.management_group_id
-    metadata            = local.metadata
+    metadata            = jsonencode(local.metadata)
     parameters          = jsonencode(local.parameters)
     policy_rule         = jsonencode(local.policy_rule)
   }

--- a/modules/definition/variables.tf
+++ b/modules/definition/variables.tf
@@ -88,16 +88,16 @@ locals {
 
   # fallbacks
   title = title(replace(local.policy_name, "/-|_|\\s/", " "))
-  category = coalesce(var.policy_category, try((local.policy_object).properties.metadata.category, null), "General")
-  version = coalesce(var.policy_version, try((local.policy_object).properties.metadata.version, null), "1.0.0")
+  category = coalesce(var.policy_category, try((local.policy_object).properties.metadata.category, "General"))
+  version = coalesce(var.policy_version, try((local.policy_object).properties.metadata.version, "1.0.0"))
 
   # use local library attributes if runtime inputs are omitted
-  policy_name = coalesce(var.policy_name, try((local.policy_object).name, null), null)
+  policy_name = coalesce(var.policy_name, try((local.policy_object).name, null))
   display_name = coalesce(var.display_name, try((local.policy_object).properties.displayName, local.title))
   description = coalesce(var.policy_description, try((local.policy_object).properties.description, local.title))
   policy_rule = coalesce(var.policy_rule, try((local.policy_object).properties.policyRule, null))
   parameters = coalesce(var.policy_parameters, try((local.policy_object).properties.parameters, null))
-  metadata = coalesce(var.policy_metadata, merge({ category = local.category },{ version = local.version }), try((local.policy_object).properties.metadata))
+  metadata = coalesce(var.policy_metadata, try((local.policy_object).properties.metadata, merge({ category = local.category },{ version = local.version })))
 
   # manually generate the definition Id to prevent "Invalid for_each argument" on set_assignment plan/apply
   definition_id = var.management_group_id != null ? "${var.management_group_id}/providers/Microsoft.Authorization/policyDefinitions/${local.policy_name}" : azurerm_policy_definition.def.id

--- a/modules/definition/variables.tf
+++ b/modules/definition/variables.tf
@@ -80,11 +80,14 @@ variable file_path {
 }
 
 locals {
-  # import the custom policy object from the library or specified file path
-  policy_object = coalesce(
-    try(jsondecode(file("${path.module}/../../policies/${title(var.policy_category)}/${var.policy_name}.json")), null),
-    try(jsondecode(file(var.file_path)), null)
-  )
+  # import the custom policy object from a library or specified file path
+  policy_object = jsondecode(coalesce(try(
+    file(var.file_path),
+    file("${path.cwd}/policies/${title(var.policy_category)}/${var.policy_name}.json"),
+    file("${path.root}/policies/${title(var.policy_category)}/${var.policy_name}.json"),
+    file("${path.root}/../policies/${title(var.policy_category)}/${var.policy_name}.json"),
+    file("${path.module}/../../policies/${title(var.policy_category)}/${var.policy_name}.json")
+  )))
 
   # fallbacks
   title = title(replace(local.policy_name, "/-|_|\\s/", " "))
@@ -95,9 +98,9 @@ locals {
   policy_name = coalesce(var.policy_name, try((local.policy_object).name, null))
   display_name = coalesce(var.display_name, try((local.policy_object).properties.displayName, local.title))
   description = coalesce(var.policy_description, try((local.policy_object).properties.description, local.title))
-  policy_rule = coalesce(var.policy_rule, try((local.policy_object).properties.policyRule, null))
-  parameters = coalesce(var.policy_parameters, try((local.policy_object).properties.parameters, null))
   metadata = coalesce(var.policy_metadata, try((local.policy_object).properties.metadata, merge({ category = local.category },{ version = local.version })))
+  parameters = coalesce(var.policy_parameters, try((local.policy_object).properties.parameters, null))
+  policy_rule = coalesce(var.policy_rule, try((local.policy_object).properties.policyRule, null))
 
   # manually generate the definition Id to prevent "Invalid for_each argument" on set_assignment plan/apply
   definition_id = var.management_group_id != null ? "${var.management_group_id}/providers/Microsoft.Authorization/policyDefinitions/${local.policy_name}" : azurerm_policy_definition.def.id

--- a/modules/initiative/README.md
+++ b/modules/initiative/README.md
@@ -121,6 +121,7 @@ No modules.
 | <a name="input_initiative_version"></a> [initiative\_version](#input\_initiative\_version) | The version for this initiative, defaults to 1.0.0 | `string` | `"1.0.0"` | no |
 | <a name="input_management_group_id"></a> [management\_group\_id](#input\_management\_group\_id) | The management group scope at which the initiative will be defined. Defaults to current Subscription if omitted. Changing this forces a new resource to be created. Note: if you are using azurerm\_management\_group to assign a value to management\_group\_id, be sure to use name or group\_id attribute, but not id. | `string` | `null` | no |
 | <a name="input_member_definitions"></a> [member\_definitions](#input\_member\_definitions) | Policy Defenition resource nodes that will be members of this initiative | `any` | n/a | yes |
+| <a name="input_merge_effects"></a> [merge\_effects](#input\_merge\_effects) | Should the module merge definition effects. Defauls to true | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/initiative/README.md
+++ b/modules/initiative/README.md
@@ -2,7 +2,8 @@
 
 Dynamically creates a policy set based on multiple policy definition references
 
-> ⚠️ **Warning:** If any two `member_definition_ids` contain the same parameters then they will be `merged()` by this module, in most cases this is beneficial but if unique values are required it may be best practice to set unique keys such as `[parameters('whitelist_resources_effect')]` instead of `[parameters('effect')]`.
+> ⚠️ **Warning:** If any two `member_definition_ids` contain the same parameters then they will be [merged](https://www.terraform.io/language/functions/merge) by this module (except for `"effect"` when setting `merge_effects = false`) [as seen here](modules/initiative/variables.tf#L74-L81). In most cases this is beneficial but if unique values are required it may be best practice to set unique keys directly within your custom definition.json files such as `[parameters('listOfResourceTypesAllowed_WhitelistResources')]` instead of `[parameters('listOfResourceTypesAllowed')]`.
+
 
 ## Examples
 
@@ -27,7 +28,9 @@ module configure_asc_initiative {
 }
 ```
 
-### Create an Initiative with a mix of custom & built-in Policy definitions
+### Create an Initiative with a mix of custom & built-in Policy definitions without merging effects
+
+When setting `merge_effects = false` the module will suffix each definition effect parameter with its respective policy definition reference Id e.g. `"effect_AutoEnrollSubscriptions"`.
 
 ```hcl
 data azurerm_policy_definition deploy_law_on_linux_vms {
@@ -41,6 +44,7 @@ module configure_asc_initiative {
   initiative_description  = "Deploys and configures Azure Security Center settings and defines exports"
   initiative_category     = "Security Center"
   management_group_id     = data.azurerm_management_group.org.id
+  merge_effects           = false
 
   member_definitions = [
     module.configure_asc["auto_enroll_subscriptions"].definition,

--- a/modules/initiative/TEMPLATE.md
+++ b/modules/initiative/TEMPLATE.md
@@ -2,7 +2,8 @@
 
 Dynamically creates a policy set based on multiple policy definition references
 
-> ⚠️ **Warning:** If any two `member_definition_ids` contain the same parameters then they will be `merged()` by this module, in most cases this is beneficial but if unique values are required it may be best practice to set unique keys such as `[parameters('whitelist_resources_effect')]` instead of `[parameters('effect')]`.
+> ⚠️ **Warning:** If any two `member_definition_ids` contain the same parameters then they will be [merged](https://www.terraform.io/language/functions/merge) by this module (except for `"effect"` when setting `merge_effects = false`) [as seen here](modules/initiative/variables.tf#L74-L81). In most cases this is beneficial but if unique values are required it may be best practice to set unique keys directly within your custom definition.json files such as `[parameters('listOfResourceTypesAllowed_WhitelistResources')]` instead of `[parameters('listOfResourceTypesAllowed')]`.
+
 
 ## Examples
 
@@ -27,7 +28,9 @@ module configure_asc_initiative {
 }
 ```
 
-### Create an Initiative with a mix of custom & built-in Policy definitions
+### Create an Initiative with a mix of custom & built-in Policy definitions without merging effects
+
+When setting `merge_effects = false` the module will suffix each definition effect parameter with its respective policy definition reference Id e.g. `"effect_AutoEnrollSubscriptions"`.
 
 ```hcl
 data azurerm_policy_definition deploy_law_on_linux_vms {
@@ -41,6 +44,7 @@ module configure_asc_initiative {
   initiative_description  = "Deploys and configures Azure Security Center settings and defines exports"
   initiative_category     = "Security Center"
   management_group_id     = data.azurerm_management_group.org.id
+  merge_effects           = false
 
   member_definitions = [
     module.configure_asc["auto_enroll_subscriptions"].definition,

--- a/modules/initiative/outputs.tf
+++ b/modules/initiative/outputs.tf
@@ -32,7 +32,7 @@ output initiative {
     description                 = var.initiative_description
     management_group_id         = var.management_group_id
     parameters                  = local.parameters
-    metadata                    = local.metadata
+    metadata                    = jsonencode(local.metadata)
     policy_definition_reference = azurerm_policy_set_definition.set.policy_definition_reference
     role_definition_ids         = local.all_role_definition_ids
   }

--- a/modules/set_assignment/README.md
+++ b/modules/set_assignment/README.md
@@ -27,7 +27,10 @@ module org_mg_configure_asc_initiative {
     data.azurerm_management_group.team_a.id
   ]
 
-  non_compliance_message = "Display this non-compliance message as opposed to a less informal policy error"
+  non_compliance_messages = {
+    null                      = "The Default non-compliance message for all member definitions"
+    "AutoEnrollSubscriptions" = "The non-compliance message for the auto_enroll_subscriptions definition"
+  }
 }
 ```
 
@@ -124,7 +127,7 @@ No modules.
 | <a name="input_assignment_scope"></a> [assignment\_scope](#input\_assignment\_scope) | The scope at which the policy initiative will be assigned. Must be full resource IDs. Changing this forces a new resource to be created | `string` | n/a | yes |
 | <a name="input_initiative"></a> [initiative](#input\_initiative) | Policy Initiative resource node | `any` | n/a | yes |
 | <a name="input_location_filters"></a> [location\_filters](#input\_location\_filters) | Optional list of the resource locations that will be remediated | `list(any)` | `[]` | no |
-| <a name="input_non_compliance_message"></a> [non\_compliance\_message](#input\_non\_compliance\_message) | The optional non-compliance message text. This message will be the default for all member definitions in the set. | `string` | `""` | no |
+| <a name="input_non_compliance_messages"></a> [non\_compliance\_messages](#input\_non\_compliance\_messages) | The optional non-compliance message(s). Key/Value pairs map as policy\_definition\_reference\_id = 'content', use null = 'content' to specify the Default non-compliance message for all member definitions. | `any` | `{}` | no |
 | <a name="input_remediation_scope"></a> [remediation\_scope](#input\_remediation\_scope) | The scope at which the remediation tasks will be created. Must be full resource IDs. Defaults to the policy assignment scope. Changing this forces a new resource to be created | `string` | `""` | no |
 | <a name="input_resource_discovery_mode"></a> [resource\_discovery\_mode](#input\_resource\_discovery\_mode) | The way that resources to remediate are discovered. Possible values are ExistingNonCompliant or ReEvaluateCompliance. Defaults to ExistingNonCompliant. Applies to subscription scope and below | `string` | `"ExistingNonCompliant"` | no |
 | <a name="input_role_assignment_scope"></a> [role\_assignment\_scope](#input\_role\_assignment\_scope) | The scope at which role definition(s) will be assigned, defaults to Policy Assignment Scope. Must be full resource IDs. Changing this forces a new resource to be created | `string` | `null` | no |

--- a/modules/set_assignment/README.md
+++ b/modules/set_assignment/README.md
@@ -120,7 +120,7 @@ No modules.
 | <a name="input_assignment_effect"></a> [assignment\_effect](#input\_assignment\_effect) | The effect of the policy. Changing this forces a new resource to be created | `string` | `null` | no |
 | <a name="input_assignment_enforcement_mode"></a> [assignment\_enforcement\_mode](#input\_assignment\_enforcement\_mode) | Control whether the assignment is enforced | `bool` | `true` | no |
 | <a name="input_assignment_location"></a> [assignment\_location](#input\_assignment\_location) | The Azure location where this policy assignment should exist, required when an Identity is assigned. Defaults to UK South. Changing this forces a new resource to be created | `string` | `"uksouth"` | no |
-| <a name="input_assignment_metadata"></a> [assignment\_metadata](#input\_assignment\_metadata) | The optional metadata for the policy assignment. | `any` | `{}` | no |
+| <a name="input_assignment_metadata"></a> [assignment\_metadata](#input\_assignment\_metadata) | The optional metadata for the policy assignment. | `any` | `null` | no |
 | <a name="input_assignment_name"></a> [assignment\_name](#input\_assignment\_name) | The name which should be used for this Policy Assignment, defaults to initiative name. Changing this forces a new Policy Assignment to be created | `string` | `""` | no |
 | <a name="input_assignment_not_scopes"></a> [assignment\_not\_scopes](#input\_assignment\_not\_scopes) | A list of the Policy Assignment's excluded scopes. Must be full resource IDs | `list(any)` | `[]` | no |
 | <a name="input_assignment_parameters"></a> [assignment\_parameters](#input\_assignment\_parameters) | The policy assignment parameters. Changing this forces a new resource to be created | `any` | `null` | no |

--- a/modules/set_assignment/README.md
+++ b/modules/set_assignment/README.md
@@ -117,6 +117,7 @@ No modules.
 | <a name="input_assignment_effect"></a> [assignment\_effect](#input\_assignment\_effect) | The effect of the policy. Changing this forces a new resource to be created | `string` | `null` | no |
 | <a name="input_assignment_enforcement_mode"></a> [assignment\_enforcement\_mode](#input\_assignment\_enforcement\_mode) | Control whether the assignment is enforced | `bool` | `true` | no |
 | <a name="input_assignment_location"></a> [assignment\_location](#input\_assignment\_location) | The Azure location where this policy assignment should exist, required when an Identity is assigned. Defaults to UK South. Changing this forces a new resource to be created | `string` | `"uksouth"` | no |
+| <a name="input_assignment_metadata"></a> [assignment\_metadata](#input\_assignment\_metadata) | The optional metadata for the policy assignment. | `any` | `{}` | no |
 | <a name="input_assignment_name"></a> [assignment\_name](#input\_assignment\_name) | The name which should be used for this Policy Assignment, defaults to initiative name. Changing this forces a new Policy Assignment to be created | `string` | `""` | no |
 | <a name="input_assignment_not_scopes"></a> [assignment\_not\_scopes](#input\_assignment\_not\_scopes) | A list of the Policy Assignment's excluded scopes. Must be full resource IDs | `list(any)` | `[]` | no |
 | <a name="input_assignment_parameters"></a> [assignment\_parameters](#input\_assignment\_parameters) | The policy assignment parameters. Changing this forces a new resource to be created | `any` | `null` | no |

--- a/modules/set_assignment/TEMPLATE.md
+++ b/modules/set_assignment/TEMPLATE.md
@@ -27,7 +27,10 @@ module org_mg_configure_asc_initiative {
     data.azurerm_management_group.team_a.id
   ]
 
-  non_compliance_message = "Display this non-compliance message as opposed to a less informal policy error"
+  non_compliance_messages = {
+    null                      = "The Default non-compliance message for all member definitions"
+    "AutoEnrollSubscriptions" = "The non-compliance message for the auto_enroll_subscriptions definition"
+  }
 }
 ```
 

--- a/modules/set_assignment/main.tf
+++ b/modules/set_assignment/main.tf
@@ -3,12 +3,12 @@ resource azurerm_management_group_policy_assignment set {
   name                 = local.assignment_name
   display_name         = local.display_name
   description          = local.description
+  metadata             = local.metadata
+  parameters           = local.parameters
   management_group_id  = var.assignment_scope
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
-  parameters           = local.parameters
-  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -33,12 +33,12 @@ resource azurerm_subscription_policy_assignment set {
   name                 = local.assignment_name
   display_name         = local.display_name
   description          = local.description
+  metadata             = local.metadata
+  parameters           = local.parameters
   subscription_id      = var.assignment_scope
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
-  parameters           = local.parameters
-  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -64,12 +64,12 @@ resource azurerm_resource_group_policy_assignment set {
   name                 = local.assignment_name
   display_name         = local.display_name
   description          = local.description
+  metadata             = local.metadata
+  parameters           = local.parameters
   resource_group_id    = var.assignment_scope
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
-  parameters           = local.parameters
-  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -94,12 +94,12 @@ resource azurerm_resource_policy_assignment set {
   name                 = local.assignment_name
   display_name         = local.display_name
   description          = local.description
+  metadata             = local.metadata
+  parameters           = local.parameters
   resource_id          = var.assignment_scope
   not_scopes           = var.assignment_not_scopes
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
-  parameters           = local.parameters
-  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {

--- a/modules/set_assignment/main.tf
+++ b/modules/set_assignment/main.tf
@@ -14,7 +14,8 @@ resource azurerm_management_group_policy_assignment set {
   dynamic "non_compliance_message" {
     for_each = local.non_compliance_message
     content {
-      content = non_compliance_message.value
+      content                        = non_compliance_message.value
+      policy_definition_reference_id = non_compliance_message.key == "null" ? null : non_compliance_message.key
     }
   }
 
@@ -43,7 +44,8 @@ resource azurerm_subscription_policy_assignment set {
   dynamic "non_compliance_message" {
     for_each = local.non_compliance_message
     content {
-      content = non_compliance_message.value
+      content                        = non_compliance_message.value
+      policy_definition_reference_id = non_compliance_message.key == "null" ? null : non_compliance_message.key
     }
   }
 
@@ -73,7 +75,8 @@ resource azurerm_resource_group_policy_assignment set {
   dynamic "non_compliance_message" {
     for_each = local.non_compliance_message
     content {
-      content = non_compliance_message.value
+      content                        = non_compliance_message.value
+      policy_definition_reference_id = non_compliance_message.key == "null" ? null : non_compliance_message.key
     }
   }
 
@@ -102,7 +105,8 @@ resource azurerm_resource_policy_assignment set {
   dynamic "non_compliance_message" {
     for_each = local.non_compliance_message
     content {
-      content = non_compliance_message.value
+      content                        = non_compliance_message.value
+      policy_definition_reference_id = non_compliance_message.key == "null" ? null : non_compliance_message.key
     }
   }
 

--- a/modules/set_assignment/main.tf
+++ b/modules/set_assignment/main.tf
@@ -8,6 +8,7 @@ resource azurerm_management_group_policy_assignment set {
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
   parameters           = local.parameters
+  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -35,6 +36,7 @@ resource azurerm_subscription_policy_assignment set {
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
   parameters           = local.parameters
+  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -63,6 +65,7 @@ resource azurerm_resource_group_policy_assignment set {
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
   parameters           = local.parameters
+  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {
@@ -90,6 +93,7 @@ resource azurerm_resource_policy_assignment set {
   enforce              = var.assignment_enforcement_mode
   policy_definition_id = var.initiative.id
   parameters           = local.parameters
+  metadata             = jsonencode(var.assignment_metadata)
   location             = var.assignment_location
 
   dynamic "non_compliance_message" {

--- a/modules/set_assignment/main.tf
+++ b/modules/set_assignment/main.tf
@@ -21,7 +21,8 @@ resource azurerm_management_group_policy_assignment set {
   dynamic "identity" {
     for_each = local.identity_type
     content {
-      type = identity.value
+      type         = identity.value
+      identity_ids = []
     }
   }
 }
@@ -49,7 +50,8 @@ resource azurerm_subscription_policy_assignment set {
   dynamic "identity" {
     for_each = local.identity_type
     content {
-      type = identity.value
+      type         = identity.value
+      identity_ids = []
     }
   }
 }
@@ -78,7 +80,8 @@ resource azurerm_resource_group_policy_assignment set {
   dynamic "identity" {
     for_each = local.identity_type
     content {
-      type = identity.value
+      type         = identity.value
+      identity_ids = []
     }
   }
 }
@@ -106,7 +109,8 @@ resource azurerm_resource_policy_assignment set {
   dynamic "identity" {
     for_each = local.identity_type
     content {
-      type = identity.value
+      type         = identity.value
+      identity_ids = []
     }
   }
 }

--- a/modules/set_assignment/variables.tf
+++ b/modules/set_assignment/variables.tf
@@ -62,10 +62,10 @@ variable assignment_location {
   default     = "uksouth"
 }
 
-variable non_compliance_message {
-  type        = string
-  description = "The optional non-compliance message text. This message will be the default for all member definitions in the set."
-  default     = ""
+variable non_compliance_messages {
+  type        = any
+  description = "The optional non-compliance message(s). Key/Value pairs map as policy_definition_reference_id = 'content', use null = 'content' to specify the Default non-compliance message for all member definitions."
+  default     = {}
 }
 
 variable resource_discovery_mode {
@@ -142,8 +142,11 @@ locals {
   # merge effect and parameter_values if specified, will use definition default effects if omitted
   parameters = var.assignment_effect != null ? jsonencode(merge(local.parameter_values, { effect = { value = var.assignment_effect } })) : jsonencode(local.parameter_values)
 
-  # create the optional non-compliance message contents block if present
-  non_compliance_message = var.non_compliance_message != "" ? { content = var.non_compliance_message } : {}
+  # create the optional non-compliance message content block(s) if present
+  non_compliance_message = var.non_compliance_messages != {} ? {
+    for reference_id, message in var.non_compliance_messages :
+    reference_id => message
+  } : {}
 
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), [])) > 0 ? { type = "SystemAssigned" } : {}

--- a/modules/set_assignment/variables.tf
+++ b/modules/set_assignment/variables.tf
@@ -120,7 +120,7 @@ locals {
   assignment_name = try(lower(substr(coalesce(var.assignment_name, var.initiative.name), 0, 24)), "")
   display_name = try(coalesce(var.assignment_display_name, var.initiative.display_name), "")
   description = try(coalesce(var.assignment_description, var.initiative.description), "")
-  metadata = jsonencode(try(coalesce(var.assignment_metadata, var.initiative.metadata), {}))
+  metadata = jsonencode(try(coalesce(var.assignment_metadata, jsondecode(var.initiative.metadata)), {}))
 
   # convert assignment parameters to the required assignment structure
   parameter_values = var.assignment_parameters != null ? {

--- a/modules/set_assignment/variables.tf
+++ b/modules/set_assignment/variables.tf
@@ -44,6 +44,12 @@ variable assignment_parameters {
   default     = null
 }
 
+variable assignment_metadata {
+  type        = any
+  description = "The optional metadata for the policy assignment."
+  default     = {}
+}
+
 variable assignment_enforcement_mode {
   type        = bool
   description = "Control whether the assignment is enforced"

--- a/policies/Monitoring/README.md
+++ b/policies/Monitoring/README.md
@@ -3,4 +3,7 @@
 Azure Monitor Policies
 
 ## References
+
 [List of Azure Policy built-in definitions for Azure Monitor](https://docs.microsoft.com/en-us/azure/azure-monitor/samples/policy-reference)
+
+[Create diagnostic settings at scale using Azure Policy](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/diagnostic-settings-policy)

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,6 +1,7 @@
 
-# Local Policy Definitions
-Compile time: 06/07/2022 12:43:59 UTC
+# Custom Policy Definition Library
+Compile time: 06/29/2022 11:46:56 UTC
+Example custom definitions located in the local library
 
 ## Categories
 - [Automation](#Automation)
@@ -1076,14 +1077,14 @@ Compile time: 06/07/2022 12:43:59 UTC
 | ----- | ----------- |
 | Name                | auto_enroll_subscriptions |
 | DisplayName         | Enroll Subscriptions to Azure Security Center |
-| Description         | Enroll Subscriptions to Azure Security Center |
+| Description         | Enroll Subscriptions to Azure Security Center Standard Pricing Tier, Note: the new Containers Plan will be replacing Container Registries and Kubernetes |
 | Effect              | [parameters('effect')] |
 
 #### 🧮 ~ Parameters
 | Name | Description | Default Value | Allowed Values |
 | ---- | ----------- | ------------- | -------------- |
 | effect | Enable or disable the execution of the policy | DeployIfNotExists | DeployIfNotExists Disabled |
-| pricingTier | ASC Pricing Tier | standard |  |
+| pricingTier | ASC Pricing Tier | Standard | Free Standard |
 
 <br>
 

--- a/policies/Security Center/auto_enroll_subscriptions.json
+++ b/policies/Security Center/auto_enroll_subscriptions.json
@@ -3,7 +3,7 @@
   "name": "auto_enroll_subscriptions",
   "properties": {
     "displayName": "Enroll Subscriptions to Azure Security Center",
-    "description": "Enroll Subscriptions to Azure Security Center",
+    "description": "Enroll Subscriptions to Azure Security Center Standard Pricing Tier, Note: the new Containers Plan will be replacing Container Registries and Kubernetes",
     "metadata": {
       "category": "Security Center"
     },
@@ -22,7 +22,11 @@
       },
       "pricingTier": {
         "type": "String",
-        "defaultValue": "standard",
+        "defaultValue": "Standard",
+        "allowedValues": [
+          "Free",
+          "Standard"
+        ],
         "metadata": {
           "displayName": "Pricing Tier",
           "description": "ASC Pricing Tier"
@@ -102,7 +106,7 @@
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "VirtualMachines",
                     "properties": {
                       "pricingTier": "[parameters('pricingTier')]"
@@ -110,7 +114,7 @@
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "StorageAccounts",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/VirtualMachines')]"
@@ -121,7 +125,7 @@
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "AppServices",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/StorageAccounts')]"
@@ -132,7 +136,7 @@
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "SqlServers",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/AppServices')]"
@@ -143,7 +147,7 @@
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "SqlServerVirtualMachines",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/SqlServers')]"
@@ -154,7 +158,7 @@
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "KeyVaults",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/SqlServerVirtualMachines')]"
@@ -165,29 +169,29 @@
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "KubernetesService",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/KeyVaults')]"
                     ],
                     "properties": {
-                      "pricingTier": "[parameters('pricingTier')]"
+                      "pricingTier": "Free"
                     }
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "ContainerRegistry",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/KubernetesService')]"
                     ],
                     "properties": {
-                      "pricingTier": "[parameters('pricingTier')]"
+                      "pricingTier": "Free"
                     }
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "Dns",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/ContainerRegistry')]"
@@ -198,10 +202,43 @@
                   },
                   {
                     "type": "Microsoft.Security/pricings",
-                    "apiVersion": "2018-06-01",
+                    "apiVersion": "2022-03-01",
                     "name": "Arm",
                     "dependsOn": [
                       "[concat('Microsoft.Security/pricings/Dns')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('pricingTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2022-03-01",
+                    "name": "OpenSourceRelationalDatabases",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/Arm')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('pricingTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2022-03-01",
+                    "name": "CosmosDbs",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/OpenSourceRelationalDatabases')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('pricingTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2022-03-01",
+                    "name": "Containers",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/CosmosDbs')]"
                     ],
                     "properties": {
                       "pricingTier": "[parameters('pricingTier')]"

--- a/scripts/markdown_generator.ps1
+++ b/scripts/markdown_generator.ps1
@@ -68,7 +68,7 @@ foreach ($child in $definitionChildren) {
 }
 
 # Output to Mardown
-$heading = "`n# Local Policy Definitions"
+$heading = "`n# Custom Policy Definition Library"
 $file = "README.md"
 
 Write-Output "$heading" | Out-File -FilePath $file -Force
@@ -78,6 +78,7 @@ $append = @{
 }
 
 Write-Output "Compile time: $(Get-Date) UTC" | Out-File @append
+Write-Output "Example custom definitions located in the local library" | Out-File @append
 
 Write-Output "`n## Categories" | Out-File @append
 foreach ($definition in $definitionList.Keys) {


### PR DESCRIPTION
## Description

- `definition` module:
  - fixes #33: Improved lookups for multiple local definition filepaths
  - fixes #32: `coalesce()` did not correctly evaluate policy object metadata into `local.metadata`
- `initiative` module:
  - fixes #20: A long awaited enhancement - new Boolean variable `var.merge_effects` allows member definitions to have unique "effect" parameters at assignment
- `*-assignment` modules:
  - fixes #31: New variable `var.assignment_metadata` 
- `set_assignment` module:
  - fixes #29: **Breaking change**: `var.non_compliance_message` attribute changed to `var.non_compliance_messages` to allow both default and definition-specific messages

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (breaking change which adds functionality)
- [x] This change requires a documentation update

**Test Configuration**:
* Module Version: 2.6.1
* Terraform Version: 1.2.3
* AzureRM Provider Version: 3.8.0
