### PR TITLE
Builtin policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ module whitelist_regions {
 
 Dynamically create a policy set based on multiple custom or built-in policy definition references to simplify assignments.
 
-
 ```hcl
 module platform_baseline_initiative {
   source                  = "gettek/policy-as-code/azurerm//modules/initiative"
@@ -225,10 +224,10 @@ To trigger an on-demand [compliance scan](https://docs.microsoft.com/en-us/azure
 
 ### 🎯Definition and Assignment Scopes
 
-  - Should be Defined as **high up** in the hierarchy as possible.
-  - Should be Assigned as **low down** in the hierarchy as possible.
-  - `assignment_not_scopes` such as child resource groups, individual resources or entire subscriptions, can be specified as enforcement exemptions.
-  - Policy **overrides RBAC** so even Subscription owners fall under the same compliance enforcements assigned at a higher scope (unless assigned at subscription scope).
+- Should be Defined as **high up** in the hierarchy as possible.
+- Should be Assigned as **low down** in the hierarchy as possible.
+- `assignment_not_scopes` such as child resource groups, individual resources or entire subscriptions, can be specified as enforcement exemptions.
+- Policy **overrides RBAC** so even Subscription owners fall under the same compliance enforcements assigned at a higher scope (unless assigned at subscription scope).
 
 ![Policy Definition and Assignment Scopes](img/scopes.svg)
 
@@ -254,9 +253,9 @@ To trigger an on-demand [compliance scan](https://docs.microsoft.com/en-us/azure
 - [Azure Citadel: Creating Custom Policies](https://www.azurecitadel.com/policy/custom/)
 - [Terraform Provider: azurerm_policy_definition](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_definition)
 - [Terraform Provider: azurerm_policy_set_definition](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_set_definition)
-- [Terraform Provider: multiple assignment resources: azurerm_*_policy_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_policy_assignment)
-- [Terraform Provider: multiple remediation resources: azurerm_*_policy_remediation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_management_group_policy_remediation)
-- [Terraform Provider: multiple exemption resources: azurerm_*_policy_exemption](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_management_group_policy_exemption)
+- [Terraform Provider: multiple assignment resources: azurerm\_\*\_policy_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_policy_assignment)
+- [Terraform Provider: multiple remediation resources: azurerm\_\*\_policy_remediation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_management_group_policy_remediation)
+- [Terraform Provider: multiple exemption resources: azurerm\_\*\_policy_exemption](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_management_group_policy_exemption)
 
 ## Limitations
 
@@ -265,7 +264,7 @@ To trigger an on-demand [compliance scan](https://docs.microsoft.com/en-us/azure
 - There's a [maximum count](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-policy-limits) for each object type for Azure Policy. For definitions, an entry of Scope means the management group or subscription. For assignments and exemptions, an entry of Scope means the management group, subscription, resource group, or individual resource:
 
 | Where                                                     | What                             | Maximum count |
-|-----------------------------------------------------------|----------------------------------|---------------|
+| --------------------------------------------------------- | -------------------------------- | ------------- |
 | Scope                                                     | Policy definitions               | 500           |
 | Scope                                                     | Initiative definitions           | 200           |
 | Tenant                                                    | Initiative definitions           | 2,500         |
@@ -279,3 +278,4 @@ To trigger an on-demand [compliance scan](https://docs.microsoft.com/en-us/azure
 | Remediation task                                          | Resources                        | 50,000        |
 | Policy definition, initiative, or assignment request body | Bytes                            | 1,048,576     |
 
+.

--- a/modules/builtin_policy/TEMPLATE.md
+++ b/modules/builtin_policy/TEMPLATE.md
@@ -1,0 +1,57 @@
+# BUILTIN POLICY MODULE
+
+This module depends on populating `var.display_name` to correspond with the respective Built-In Policy definition in Azure.
+
+> 💡 **Note:** More information on Policy Definition Structure [can be found here](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure)
+
+## Examples
+
+### Get Policy Definition from terraform data source
+
+```hcl
+module "builtin_policy" {
+  source      = "gettek/policy-as-code/azurerm//modules/builtin_policy"
+  policy_name = "Allowed locations"
+}
+
+```
+
+### Loop around a map to quickly get multiple definitions
+
+```hcl
+locals {
+  corp_policies = [
+    // MFA
+    "MFA should be enabled on accounts with owner permissions on your subscription",
+    "MFA should be enabled accounts with write permissions on your subscription",
+    // Location
+    "Allowed locations",
+    "Allowed locations for resource groups",
+  ]
+}
+
+module "builtin_policies" {
+  source      = "gettek/policy-as-code/azurerm//modules/builtin_policy"
+  for_each    = toset(local.corp_policies)
+  policy_name = each.value
+}
+
+```
+
+### Use received data to be used in Initiative Definition
+
+```hcl
+module "corp_def_initiative" {
+  source                  = "gettek/policy-as-code/azurerm//modules/initiative"
+  initiative_name         = "corp_def_initiative"
+  initiative_display_name = "[corp] Initiative assignment"
+  initiative_description  = "Deploys and configures policies for corp Management Group"
+  initiative_category     = "General"
+  management_group_id     = data.azurerm_management_group.corp.id
+
+  # Populate member_definitions with a for loop (explicit)
+  member_definitions = [
+    for policy in local.corp_policies : module.builtin_policies[policy].definition
+  ]
+}
+```

--- a/modules/builtin_policy/main.tf
+++ b/modules/builtin_policy/main.tf
@@ -1,0 +1,3 @@
+data "azurerm_policy_definition" "def_builtin" {
+  display_name = var.display_name
+}

--- a/modules/builtin_policy/outputs.tf
+++ b/modules/builtin_policy/outputs.tf
@@ -1,0 +1,36 @@
+output "id" {
+  description = "The Id of the Policy Definition"
+  value       = data.azurerm_policy_definition.def_builtin.id
+}
+
+output "name" {
+  description = "The display name of the Policy Definition"
+  value       = var.display_name
+}
+
+output "rules" {
+  description = "The rules of the Policy Definition"
+  value       = data.azurerm_policy_definition.def_builtin.policy_rule
+}
+
+output "parameters" {
+  description = "The parameters of the Policy Definition"
+  value       = data.azurerm_policy_definition.def_builtin.parameters
+}
+
+output "metadata" {
+  description = "The metadata of the Policy Definition"
+  value       = data.azurerm_policy_definition.def_builtin.metadata
+}
+
+output "definition" {
+  description = "Policy definition from data source"
+  value = {
+    id          = data.azurerm_policy_definition.def_builtin.id
+    name        = var.display_name
+    description = data.azurerm_policy_definition.def_builtin.description
+    metadata    = data.azurerm_policy_definition.def_builtin.metadata
+    parameters  = data.azurerm_policy_definition.def_builtin.parameters
+    policy_rule = data.azurerm_policy_definition.def_builtin.policy_rule
+  }
+}

--- a/modules/builtin_policy/variables.tf
+++ b/modules/builtin_policy/variables.tf
@@ -1,0 +1,10 @@
+variable "display_name" {
+  type        = string
+  description = "displayName of the policy in Azure policy definition, not to be confsed with name (id)"
+  default     = ""
+
+  validation {
+    condition     = length(var.display_name) <= 128
+    error_message = "Definition display names have a maximum 128 character limit."
+  }
+}

--- a/modules/initiative/main.tf
+++ b/modules/initiative/main.tf
@@ -13,7 +13,8 @@ resource azurerm_policy_set_definition set {
     for_each = [for d in var.member_definitions : {
       id         = d.id
       ref_id     = replace(substr(title(replace(d.name, "/-|_|\\s/", " ")), 0, 64), "/\\s/", "")
-      parameters = jsondecode(d.parameters)
+      // in Built-In policies parameters may be empty
+      parameters = try(jsondecode(d.parameters), {})
       groups     = []
     }]
 

--- a/modules/initiative/variables.tf
+++ b/modules/initiative/variables.tf
@@ -74,7 +74,8 @@ locals {
   # colate all definition parameters into a single object
   member_parameters = {
     for d in var.member_definitions :
-    d.name => try(jsondecode(d.parameters), null)
+    // in Built-In policies parameters may be empty
+    d.name => try(jsondecode(d.parameters), {})
   }
 
   # combine all discovered definition parameters using interpolation


### PR DESCRIPTION
# Add Built-In Policies module

## Description
I wanted to be able to Define Initiatives using Built-In Azure Policies, rather than defining them in local json files. New module called 'builtin_policy' was created. It's basically a data source which requires displayName of the policy and returns data that's required by 'set_assignment' module.

Fixes # (issue)
I believe I fixed a small issue in the 'set_assignment' module. It used to fail when policy had not parameters (which can be the case in Built-In policies, for example "Network interfaces should not have public IPs"). Now, it's using "{}" instead of null so it no longer fails.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I set this module in my terraform pipeline ("git::https://github.com/szczyrja/terraform-azurerm-policy-as-code.git//modules/set_assignment?ref=builtin_policy") and ran terraform code.

**Test Configuration**:
* Module Version:
* Terraform Version: 1.2.9
* AzureRM Provider Version: v3.23.0

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (well I get "Argument is deprecated" because of "`policy_definition_id` will be removed in version 4.0 of the AzureRM Provider in favour of `policy_definition_reference_id`." because 3.23.0 is already out. I don't want to change your module though unless you let me).
- [x] I have checked my code and corrected any misspellings

I accidentally edited the main README file with my IDE, this is not intended.