### PR TITLE
2.6.5

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This module depends on populating `var.policy_name` and `var.policy_category` to
 ```hcl
 module whitelist_regions {
   source              = "gettek/policy-as-code/azurerm//modules/definition"
-  version             = "2.6.4"
+  version             = "2.6.5"
   policy_name         = "whitelist_regions"
   display_name        = "Allow resources only in whitelisted regions"
   policy_category     = "General"
@@ -97,7 +97,7 @@ Dynamically create a policy set based on multiple custom or built-in policy defi
 ```hcl
 module platform_baseline_initiative {
   source                  = "gettek/policy-as-code/azurerm//modules/initiative"
-  version                 = "2.6.4"
+  version                 = "2.6.5"
   initiative_name         = "platform_baseline_initiative"
   initiative_display_name = "[Platform]: Baseline Policy Set"
   initiative_description  = "Collection of policies representing the baseline platform requirements"
@@ -118,7 +118,7 @@ module platform_baseline_initiative {
 ```hcl
 module org_mg_whitelist_regions {
   source            = "gettek/policy-as-code/azurerm//modules/def_assignment"
-  version           = "2.6.4"
+  version           = "2.6.5"
   definition        = module.whitelist_regions.definition
   assignment_scope  = data.azurerm_management_group.org.id
   assignment_effect = "Deny"
@@ -140,7 +140,7 @@ module org_mg_whitelist_regions {
 ```hcl
 module org_mg_platform_diagnostics_initiative {
   source                  = "gettek/policy-as-code/azurerm//modules/set_assignment"
-  version                 = "2.6.4"
+  version                 = "2.6.5"
   initiative              = module.platform_diagnostics_initiative.initiative
   assignment_scope        = data.azurerm_management_group.org.id
   assignment_effect       = "DeployIfNotExists"
@@ -277,4 +277,6 @@ To trigger an on-demand [compliance scan](https://docs.microsoft.com/en-us/azure
 | Policy rule                                               | Nested conditionals              | 512           |
 | Remediation task                                          | Resources                        | 50,000        |
 | Policy definition, initiative, or assignment request body | Bytes                            | 1,048,576     |
+
+Policy rules have additional limits to the number of conditions and their complexity. See [Policy rule limits](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/governance/policy/concepts/definition-structure.md#policy-rule-limits) for more details.
 

--- a/modules/initiative/README.md
+++ b/modules/initiative/README.md
@@ -1,9 +1,10 @@
 # POLICY INITIATIVE MODULE
 
-Dynamically creates a policy set based on multiple custom or built-in policy definition references
+Dynamically creates a policy set based on multiple custom or built-in policy definitions
 
-> ⚠️ **Warning:** If any `member_definitions` contain the same parameter names then they will be [merged](https://www.terraform.io/language/functions/merge) by this module unless you specify `merge_effects = false` or `merge_parameters = false` [as seen here](variables.tf#L80-L92).
+> ⚠️ **Warning:** To simplify assignments, if any `member_definitions` contain the same parameter names they will be [merged](https://www.terraform.io/language/functions/merge) unless you specify `merge_effects = false` or `merge_parameters = false` as described in the second example below.
 
+> 💡 **Note:** Multiple entries of the same `member_definitions` are not currently supported, if you require the same definition to be present more than once you may use this module to create the initiative json which you can then edit to add unique parameter and definition references.
 
 ## Examples
 
@@ -30,7 +31,7 @@ module configure_asc_initiative {
 
 ### Create an Initiative with a mix of custom & built-in Policy definitions without merging effects
 
-When setting `merge_effects = false` the module will suffix each definition effect parameter with its respective policy definition reference Id e.g. `"effect_AutoEnrollSubscriptions"`.
+When setting `merge_effects = false` each definition effect parameter will be suffixed with its respective policy definition reference Id e.g. `"effect_AutoEnrollSubscriptions"`.
 
 ```hcl
 data azurerm_policy_definition deploy_law_on_linux_vms {
@@ -69,7 +70,7 @@ locals {
   ]
 }
 
-module "guest_config_prereqs" {
+module guest_config_prereqs {
   source                = "..//modules/definition"
   for_each              = toset(local.guest_config_prereqs)
   policy_name           = each.value
@@ -77,7 +78,7 @@ module "guest_config_prereqs" {
   management_group_id   = data.azurerm_management_group.org.id
 }
 
-module "guest_config_prereqs_initiative" {
+module guest_config_prereqs_initiative {
   source                  = "..//modules/initiative"
   initiative_name         = "guest_config_prereqs_initiative"
   initiative_display_name = "[GC]: Deploys Guest Config Prerequisites"
@@ -125,8 +126,8 @@ No modules.
 | <a name="input_initiative_version"></a> [initiative\_version](#input\_initiative\_version) | The version for this initiative, defaults to 1.0.0 | `string` | `"1.0.0"` | no |
 | <a name="input_management_group_id"></a> [management\_group\_id](#input\_management\_group\_id) | The management group scope at which the initiative will be defined. Defaults to current Subscription if omitted. Changing this forces a new resource to be created. Note: if you are using azurerm\_management\_group to assign a value to management\_group\_id, be sure to use name or group\_id attribute, but not id. | `string` | `null` | no |
 | <a name="input_member_definitions"></a> [member\_definitions](#input\_member\_definitions) | Policy Defenition resource nodes that will be members of this initiative | `any` | n/a | yes |
-| <a name="input_merge_effects"></a> [merge\_effects](#input\_merge\_effects) | Should the module merge all definition effects? Defauls to true | `bool` | `true` | no |
-| <a name="input_merge_parameters"></a> [merge\_parameters](#input\_merge\_parameters) | Should the module merge all definition parameters? Defauls to true | `bool` | `true` | no |
+| <a name="input_merge_effects"></a> [merge\_effects](#input\_merge\_effects) | Should the module merge all member definition effects? Defauls to true | `bool` | `true` | no |
+| <a name="input_merge_parameters"></a> [merge\_parameters](#input\_merge\_parameters) | Should the module merge all member definition parameters? Defauls to true | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/initiative/TEMPLATE.md
+++ b/modules/initiative/TEMPLATE.md
@@ -1,9 +1,10 @@
 # POLICY INITIATIVE MODULE
 
-Dynamically creates a policy set based on multiple custom or built-in policy definition references
+Dynamically creates a policy set based on multiple custom or built-in policy definitions
 
-> ⚠️ **Warning:** If any `member_definitions` contain the same parameter names then they will be [merged](https://www.terraform.io/language/functions/merge) by this module unless you specify `merge_effects = false` or `merge_parameters = false` [as seen here](variables.tf#L80-L92).
+> ⚠️ **Warning:** To simplify assignments, if any `member_definitions` contain the same parameter names they will be [merged](https://www.terraform.io/language/functions/merge) unless you specify `merge_effects = false` or `merge_parameters = false` as described in the second example below.
 
+> 💡 **Note:** Multiple entries of the same `member_definitions` are not currently supported, if you require the same definition to be present more than once you may use this module to create the initiative json which you can then edit to add unique parameter and definition references.
 
 ## Examples
 
@@ -30,7 +31,7 @@ module configure_asc_initiative {
 
 ### Create an Initiative with a mix of custom & built-in Policy definitions without merging effects
 
-When setting `merge_effects = false` the module will suffix each definition effect parameter with its respective policy definition reference Id e.g. `"effect_AutoEnrollSubscriptions"`.
+When setting `merge_effects = false` each definition effect parameter will be suffixed with its respective policy definition reference Id e.g. `"effect_AutoEnrollSubscriptions"`.
 
 ```hcl
 data azurerm_policy_definition deploy_law_on_linux_vms {
@@ -69,7 +70,7 @@ locals {
   ]
 }
 
-module "guest_config_prereqs" {
+module guest_config_prereqs {
   source                = "..//modules/definition"
   for_each              = toset(local.guest_config_prereqs)
   policy_name           = each.value
@@ -77,7 +78,7 @@ module "guest_config_prereqs" {
   management_group_id   = data.azurerm_management_group.org.id
 }
 
-module "guest_config_prereqs_initiative" {
+module guest_config_prereqs_initiative {
   source                  = "..//modules/initiative"
   initiative_name         = "guest_config_prereqs_initiative"
   initiative_display_name = "[GC]: Deploys Guest Config Prerequisites"

--- a/scripts/markdown_generator.ps1
+++ b/scripts/markdown_generator.ps1
@@ -76,8 +76,7 @@ $append = @{
     "FilePath" = $file
 }
 
-Write-Output "Compile time: $(Get-Date) UTC" | Out-File @append
-Write-Output "Example custom definitions located in the local library" | Out-File @append
+Write-Output "Compile time: $(Get-Date) UTC`nExample custom definitions located in the local library" | Out-File @append
 
 Write-Output "`n## Categories" | Out-File @append
 foreach ($definition in $definitionList.Keys) {


### PR DESCRIPTION
# 2.6.5

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #52 - `initiative` module now populates parameter `displayName` making it easier identify definition references

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**Test Configuration**:
* Module Version: 2.6.5
* Terraform Version: v1.3.2
* AzureRM Provider Version: 3.23.0
