### PR TITLE
fix definition object properties

### DIFF
--- a/examples/definitions.tf
+++ b/examples/definitions.tf
@@ -93,3 +93,24 @@ module "inherit_resource_group_tags_modify" {
   policy_mode         = "Indexed"
   management_group_id = data.azurerm_management_group.org.id
 }
+
+##################
+# object properties at runtime:
+##################
+locals {
+  policy_file = jsondecode(file("${path.module}/../policies/Automation/onboard_to_automation_dsc_linux.json"))
+}
+
+module "parameterised_test" {
+  source              = "..//modules/definition"
+  policy_name         = "Custom Name"
+  display_name        = "Custom Display Name"
+  policy_description  = "Custom Description"
+  policy_category     = "Custom Category"
+  policy_version      = "Custom Version"
+  management_group_id = data.azurerm_management_group.org.id
+
+  policy_rule       = (local.policy_file).properties.policyRule
+  policy_parameters = (local.policy_file).properties.parameters
+  policy_metadata   = (local.policy_file).properties.metadata
+}

--- a/modules/definition/variables.tf
+++ b/modules/definition/variables.tf
@@ -91,7 +91,8 @@ locals {
     file("${path.cwd}/policies/${title(var.policy_category)}/${var.policy_name}.json"),
     file("${path.root}/policies/${title(var.policy_category)}/${var.policy_name}.json"),
     file("${path.root}/../policies/${title(var.policy_category)}/${var.policy_name}.json"),
-    file("${path.module}/../../policies/${title(var.policy_category)}/${var.policy_name}.json")
+    file("${path.module}/../../policies/${title(var.policy_category)}/${var.policy_name}.json"),
+    "{}"
   )))
 
   # fallbacks

--- a/modules/definition/variables.tf
+++ b/modules/definition/variables.tf
@@ -92,7 +92,7 @@ locals {
     file("${path.root}/policies/${title(var.policy_category)}/${var.policy_name}.json"),
     file("${path.root}/../policies/${title(var.policy_category)}/${var.policy_name}.json"),
     file("${path.module}/../../policies/${title(var.policy_category)}/${var.policy_name}.json"),
-    "{}"
+    "{}" # return empty object if no policy is found
   )))
 
   # fallbacks


### PR DESCRIPTION
# Pull Request Template

## Description
This PR fixes the issue preventing policy objects to be passed into the definition module (rather than loading from a file), this is useful for when Terraform generates the policy definition eg using `templatefile()`

Fixes #79 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] tested example in `modules/definition/README.md` under "You will also be able to supply object properties at runtime such as:"
- [ ] added use case to `examples/definitions.tf` to be tested during actions

**Test Configuration**:
* Module Version: `2.8.0`
* Terraform Version: `v1.4.6`
* AzureRM Provider Version: `v3.56.0`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
