### PR TITLE
2.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
   <br>
   <h1 align="center">Azure Policy as Code with Terraform</h1>
   <p align="center">
-    <a href="https://registry.terraform.io/modules/gettek/policy-as-code/azurerm/"><img src="https://img.shields.io/badge/dynamic/json?url=https://registry.terraform.io/v2/modules/gettek/policy-as-code/azurerm/downloads/summary&logo=terraform&label=Registry%20Downloads&query=$.data.attributes.total&color=844FBA&logoColor=844FBA" alt="Terraform Registry"></a></br>
-    <a href="https://github.dev/gettek/terraform-azurerm-policy-as-code"><img src="https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc" alt="Open in Visual Studio Code"></a></br>
     <a href="https://github.com/gettek/terraform-azurerm-policy-as-code/actions/workflows/cd.yml"><img src="https://github.com/gettek/terraform-azurerm-policy-as-code/actions/workflows/cd.yml/badge.svg?branch=main" alt="CD Tests"></a>
     <a href="https://github.com/gettek/terraform-azurerm-policy-as-code/actions/workflows/ci.yml"><img src="https://github.com/gettek/terraform-azurerm-policy-as-code/actions/workflows/ci.yml/badge.svg" alt="CI Tests"></a></br>
     <a href="https://github.com/gettek/terraform-azurerm-policy-as-code/discussions"><img src="https://img.shields.io/badge/topic-discussions-yellowgreen.svg" alt="Go to topic discussions"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-orange.svg" alt="MIT License"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-orange.svg" alt="MIT License"></a></br>
+    <a href="https://github.dev/gettek/terraform-azurerm-policy-as-code"><img src="https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc" alt="Open in Visual Studio Code"></a>
+    </br>
+    <a href="https://registry.terraform.io/modules/gettek/policy-as-code/azurerm/"><img src="https://img.shields.io/badge/dynamic/json?url=https://registry.terraform.io/v2/modules/gettek/policy-as-code/azurerm/downloads/summary&logo=terraform&label=Registry%20Downloads&query=$.data.attributes.total&color=844FBA&logoColor=844FBA" alt="Terraform Registry"></a>
   </p>
 </p>
 <!-- markdownlint-enable MD033 -->
@@ -258,7 +259,8 @@ To trigger an on-demand [compliance scan](https://learn.microsoft.com/en-us/azur
 
 ## Limitations
 
-- `DefinitionName` has a maximum length of **64** characters and `AssignmentName` a maximum length of **24** characters
+- `DefinitionName` and `InitiativeName` has a maximum length of **64** characters
+- `AssignmentName` has maximum length of **24** characters at Management Group Scope and **64** characters at all other Scopes
 - `DisplayName` has a maximum length of **128** characters and `description` a maximum length of **512** characters
 - There's a [maximum count](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-policy-limits) for each object type for Azure Policy. For definitions, an entry of Scope means the management group or subscription. For assignments and exemptions, an entry of Scope means the management group, subscription, resource group, or individual resource:
 

--- a/modules/def_assignment/variables.tf
+++ b/modules/def_assignment/variables.tf
@@ -141,11 +141,12 @@ variable "skip_role_assignment" {
 }
 
 locals {
-  # assignment_name will be trimmed if exceeds 24 characters
-  assignment_name = try(lower(substr(coalesce(var.assignment_name, var.definition.name), 0, 24)), "")
-  display_name    = try(coalesce(var.assignment_display_name, var.definition.display_name), "")
-  description     = try(coalesce(var.assignment_description, var.definition.description), "")
-  metadata        = jsonencode(try(coalesce(var.assignment_metadata, jsondecode(var.definition.metadata)), {}))
+  # assignment_name at MG scope will be trimmed if exceeds 24 characters
+  assignment_name_trim = local.assignment_scope.mg > 0 ? 24 : 64
+  assignment_name      = try(lower(substr(coalesce(var.assignment_name, var.definition.name), 0, local.assignment_name_trim)), "")
+  display_name         = try(coalesce(var.assignment_display_name, var.definition.display_name), "")
+  description          = try(coalesce(var.assignment_description, var.definition.description), "")
+  metadata             = jsonencode(try(coalesce(var.assignment_metadata, jsondecode(var.definition.metadata)), {}))
 
   # convert assignment parameters to the required assignment structure
   parameter_values = var.assignment_parameters != null ? {

--- a/modules/set_assignment/variables.tf
+++ b/modules/set_assignment/variables.tf
@@ -147,8 +147,9 @@ variable "skip_role_assignment" {
 }
 
 locals {
-  # assignment_name will be trimmed if exceeds 24 characters
-  assignment_name = try(lower(substr(coalesce(var.assignment_name, var.initiative.name), 0, 24)), "")
+  # assignment_name at MG scope will be trimmed if exceeds 24 characters
+  assignment_name_trim = local.assignment_scope.mg > 0 ? 24 : 64
+  assignment_name = try(lower(substr(coalesce(var.assignment_name, var.initiative.name), 0, local.assignment_name_trim)), "")
   display_name    = try(coalesce(var.assignment_display_name, var.initiative.display_name), "")
   description     = try(coalesce(var.assignment_description, var.initiative.description), "")
   metadata        = jsonencode(try(coalesce(var.assignment_metadata, jsondecode(var.initiative.metadata)), {}))


### PR DESCRIPTION
## Description

`assignment_name` should be trimmed to **24** characters if scope is at Management Group and **64** characters for all other scopes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

Test Configuration:

- Module Version: 2.8.1
- Terraform Version: 1.3.2
- AzureRM Provider Version: 3.53.0