### PR TITLE
Fixing assignment_effect not honored if no assignment_parameters set

### DIFF
--- a/modules/def_assignment/variables.tf
+++ b/modules/def_assignment/variables.tf
@@ -161,7 +161,7 @@ locals {
   } : null
 
   # merge effect with parameter_values if specified, will use definition defaults if omitted
-  parameters = local.parameter_values != null ? var.assignment_effect != null ? jsonencode(merge(local.parameter_values, { effect = { value = var.assignment_effect } })) : jsonencode(local.parameter_values) : null
+  parameters = var.assignment_effect != null ? jsonencode(merge(local.parameter_values, { effect = { value = var.assignment_effect } })) : (local.parameter_values != null ? jsonencode(local.parameter_values) : null)
 
   # create the optional non-compliance message contents block if present
   non_compliance_message = contains(["All", "Indexed"], try(var.definition.mode, "")) ? { content = try(coalesce(var.non_compliance_message, local.description, local.display_name, "Flagged by Policy: ${local.assignment_name}", "")) } : {}

--- a/modules/set_assignment/variables.tf
+++ b/modules/set_assignment/variables.tf
@@ -167,7 +167,7 @@ locals {
   } : null
 
   # merge effect and parameter_values if specified, will use definition default effects if omitted
-  parameters = local.parameter_values != null ? var.assignment_effect != null ? jsonencode(merge(local.parameter_values, { effect = { value = var.assignment_effect } })) : jsonencode(local.parameter_values) : null
+  parameters = var.assignment_effect != null ? jsonencode(merge(local.parameter_values, { effect = { value = var.assignment_effect } })) : (local.parameter_values != null ? jsonencode(local.parameter_values) : null)
 
   # determine if a managed identity should be created with this assignment
   identity_type = length(try(coalescelist(var.role_definition_ids, try(var.initiative.role_definition_ids, [])), [])) > 0 ? var.identity_ids != null ? { type = "UserAssigned" } : { type = "SystemAssigned" } : {}


### PR DESCRIPTION
# Pull Request Template

## Description

The "assignment_effect" parameter has no effect if no "assignment_parameters are set". The condition in /def_assignment/variables.tf returns null if "local.parameter_values" is null which it is if "var.assignment_parameters" is null.

This was sort of talked about in #59. At least the condition was introduced in the fix for that issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Assigned policies with no parameters but with effect
- [x] Assigned policies with parameters and with effect
- [x] Assigned policies without parameters and without effect  

**Test Configuration**:
* Module Version: 2.8.3
* Terraform Version: 1.12.2
* AzureRM Provider Version: 4.12

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
